### PR TITLE
Create full width text component

### DIFF
--- a/src/components/fullWidthText.tsx
+++ b/src/components/fullWidthText.tsx
@@ -11,8 +11,10 @@ import { headline, titlepiece } from "@guardian/src-foundations/typography";
 import { ReactElement } from "react";
 import { minWidth } from "../styles/breakpoints";
 
+type Theme = "light" | "dark";
+
 interface FullWidthTextProps {
-  theme: string;
+  theme: Theme;
   children: ReactElement;
   title?: string;
 }

--- a/src/components/fullWidthText.tsx
+++ b/src/components/fullWidthText.tsx
@@ -69,13 +69,14 @@ const FullWidthText = (props: FullWidthTextProps) => {
           fontWeight: "regular",
           lineHeight: "loose",
         })};
+        font-size: 35px;
       }
       h2 {
         ${titlepiece.large({ fontWeight: "regular", lineHeight: "loose" })};
       }
     }
     ${minWidth.wide} {
-      padding: 85px 95px 85px 259px;
+      padding: 85px 91px 85px 259px;
     }
   `;
 

--- a/src/components/fullWidthText.tsx
+++ b/src/components/fullWidthText.tsx
@@ -38,7 +38,10 @@ const FullWidthText = (props: FullWidthTextProps) => {
     display: block;
     max-width: 1300px;
     margin: 0 auto;
-    padding: 42px ${space[6]}px;
+    padding-top: ${props.title ? space[5] : "39"}px;
+    padding-bottom: ${props.title ? "53" : "39"}px;
+    padding-left: ${space[5]}px;
+    padding-right: ${space[5]}px;
     p {
       ${headline.xxsmall({
         fontWeight: "regular",
@@ -46,12 +49,19 @@ const FullWidthText = (props: FullWidthTextProps) => {
       })};
       margin: 0;
     }
+    p + p {
+      margin-top: 0.75em;
+    }
     h2 {
-      ${titlepiece.small({ fontWeight: "regular", lineHeight: "loose" })};
-      margin: 0;
+      ${titlepiece.small({ fontWeight: "regular" })};
+      margin: 0 0 0.5em;
+      line-height: 1;
     }
     ${minWidth.tablet} {
-      padding: 70px 140px;
+      padding-top: ${props.title ? space[5] : "70"}px;
+      padding-bottom: ${props.title ? "65" : "70"}px;
+      padding-left: 140px;
+      padding-right: 140px;
       p {
         ${headline.small({
           fontWeight: "regular",
@@ -59,24 +69,28 @@ const FullWidthText = (props: FullWidthTextProps) => {
         })};
       }
       h2 {
-        ${titlepiece.medium({ fontWeight: "regular", lineHeight: "loose" })};
+        ${titlepiece.medium({ fontWeight: "regular" })};
+        line-height: 1;
       }
     }
     ${minWidth.desktop} {
-      padding: 95px 100px;
+      padding-top: ${props.title ? "45" : "95"}px;
+      padding-bottom: ${props.title ? "112" : "95"}px;
+      padding-left: 100px;
+      padding-right: 100px;
       p {
-        ${headline.medium({
-          fontWeight: "regular",
-          lineHeight: "loose",
-        })};
         font-size: 35px;
       }
       h2 {
-        ${titlepiece.large({ fontWeight: "regular", lineHeight: "loose" })};
+        ${titlepiece.large({ fontWeight: "regular" })};
+        line-height: 1;
       }
     }
     ${minWidth.wide} {
-      padding: 85px 91px 85px 259px;
+      padding-top: ${props.title ? "45" : "85"}px;
+      padding-bottom: ${props.title ? "93" : "85"}px;
+      padding-left: 259px;
+      padding-right: 91px;
     }
   `;
 

--- a/src/components/fullWidthText.tsx
+++ b/src/components/fullWidthText.tsx
@@ -73,7 +73,7 @@ const FullWidthText = (props: FullWidthTextProps) => {
       }
     }
     ${minWidth.wide} {
-      padding: 85px 170px 85px 330px;
+      padding: 85px 95px 85px 259px;
     }
   `;
 

--- a/src/components/fullWidthText.tsx
+++ b/src/components/fullWidthText.tsx
@@ -1,13 +1,20 @@
 /** @jsxRuntime classic /
 /** @jsx jsx */
 import { jsx, css } from "@emotion/react";
-import { brandAlt, neutral, space } from "@guardian/src-foundations";
-import { headline } from "@guardian/src-foundations/typography";
-import { ReactNode } from "react";
+import {
+  background,
+  brandAlt,
+  neutral,
+  space,
+} from "@guardian/src-foundations";
+import { headline, titlepiece } from "@guardian/src-foundations/typography";
+import { ReactElement } from "react";
+import { minWidth } from "../styles/breakpoints";
 
 interface FullWidthTextProps {
   theme: string;
-  children: ReactNode;
+  children: ReactElement;
+  title?: string;
 }
 
 export const highlightedCss = css`
@@ -15,45 +22,69 @@ export const highlightedCss = css`
 `;
 
 const FullWidthText = (props: FullWidthTextProps) => {
+  const containerCss = css`
+    background-color: ${props.theme === "light"
+      ? background.primary
+      : background.ctaPrimary};
+  `;
+
   const fullWidthTextCss = css`
-    background-color: ${props.theme === "light" ? neutral[100] : brandAlt[400]};
+    background-color: ${props.theme === "light"
+      ? background.primary
+      : background.ctaPrimary};
     color: ${props.theme === "light" ? neutral[7] : neutral[100]};
     display: block;
-    overflow: hidden;
+    max-width: 1300px;
+    margin: 0 auto;
+    padding: 42px ${space[6]}px;
     p {
-      margin: 42px ${space[6]}px;
       ${headline.xxsmall({
         fontWeight: "regular",
         lineHeight: "loose",
       })};
+      margin: 0;
     }
-    // update breakpoints
-    @media only screen and (min-width: 740px) {
+    h2 {
+      ${titlepiece.small({ fontWeight: "regular", lineHeight: "loose" })};
+      margin: 0;
+    }
+    ${minWidth.tablet} {
+      padding: 70px 140px;
       p {
-        margin: 70px 140px;
         ${headline.small({
           fontWeight: "regular",
           lineHeight: "loose",
         })};
       }
+      h2 {
+        ${titlepiece.medium({ fontWeight: "regular", lineHeight: "loose" })};
+      }
     }
-    @media only screen and (min-width: 980px) {
+    ${minWidth.desktop} {
+      padding: 95px 100px;
       p {
-        margin: 95px 100px;
         ${headline.medium({
           fontWeight: "regular",
           lineHeight: "loose",
         })};
       }
-    }
-    @media only screen and (min-width: 1300px) {
-      p {
-        margin: 85px 170px 85px 330px;
+      h2 {
+        ${titlepiece.large({ fontWeight: "regular", lineHeight: "loose" })};
       }
+    }
+    ${minWidth.wide} {
+      padding: 85px 170px 85px 330px;
     }
   `;
 
-  return <div css={fullWidthTextCss}>{props.children}</div>;
+  return (
+    <div css={containerCss}>
+      <div css={fullWidthTextCss}>
+        {props.title && <h2>{props.title}</h2>}
+        {props.children}
+      </div>
+    </div>
+  );
 };
 
 export default FullWidthText;

--- a/src/components/fullWidthText.tsx
+++ b/src/components/fullWidthText.tsx
@@ -1,0 +1,59 @@
+/** @jsxRuntime classic /
+/** @jsx jsx */
+import { jsx, css } from "@emotion/react";
+import { brandAlt, neutral, space } from "@guardian/src-foundations";
+import { headline } from "@guardian/src-foundations/typography";
+import { ReactNode } from "react";
+
+interface FullWidthTextProps {
+  theme: string;
+  children: ReactNode;
+}
+
+export const highlightedCss = css`
+  background-color: ${brandAlt[400]};
+`;
+
+const FullWidthText = (props: FullWidthTextProps) => {
+  const fullWidthTextCss = css`
+    background-color: ${props.theme === "light" ? neutral[100] : brandAlt[400]};
+    color: ${props.theme === "light" ? neutral[7] : neutral[100]};
+    display: block;
+    overflow: hidden;
+    p {
+      margin: 42px ${space[6]}px;
+      ${headline.xxsmall({
+        fontWeight: "regular",
+        lineHeight: "loose",
+      })};
+    }
+    // update breakpoints
+    @media only screen and (min-width: 740px) {
+      p {
+        margin: 70px 140px;
+        ${headline.small({
+          fontWeight: "regular",
+          lineHeight: "loose",
+        })};
+      }
+    }
+    @media only screen and (min-width: 980px) {
+      p {
+        margin: 95px 100px;
+        ${headline.medium({
+          fontWeight: "regular",
+          lineHeight: "loose",
+        })};
+      }
+    }
+    @media only screen and (min-width: 1300px) {
+      p {
+        margin: 85px 170px 85px 330px;
+      }
+    }
+  `;
+
+  return <div css={fullWidthTextCss}>{props.children}</div>;
+};
+
+export default FullWidthText;

--- a/src/components/pageStyles.tsx
+++ b/src/components/pageStyles.tsx
@@ -8,6 +8,7 @@ export const PageStyles = () => (
     styles={css`
       ${fonts};
       ${resets.defaults};
+
       body {
         margin: 0;
         padding: 0;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -42,8 +42,9 @@ const HomePage = () => (
       <p>
         Guardian Media Group is a global news organisation that delivers{" "}
         <span css={highlightedCss}>fearless, investigative journalism</span> -
-        giving a voice to the powerless and holding power to account. Our
-        independent ownership structure means we are entirely free from
+        giving a voice to the powerless and holding power to account.
+        <br />
+        Our independent ownership structure means we are entirely free from
         political and commercial influence.{" "}
         <span css={highlightedCss}>
           Only our values determine the stories we choose to cover

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,8 @@
 /** @jsxRuntime classic /
 /** @jsx jsx */
-import { jsx } from "@emotion/react";
+import { jsx, css } from "@emotion/react";
 import React from "react";
+import FullWidthText, { highlightedCss } from "../components/fullWidthText";
 import HeaderQuote from "../components/headerQuote";
 import { PageStyles } from "../components/pageStyles";
 import Header from "../components/header";
@@ -37,6 +38,19 @@ const HomePage = () => (
       quote="Since 1821 the mission of The Guardian has been to use clarity and imagination to build hope."
       author="Katharine Viner, editor-in-chief"
     />
+    <FullWidthText theme="light">
+      <p>
+        Guardian Media Group is a global news organisation that delivers{" "}
+        <span css={highlightedCss}>fearless, investigative journalism</span> -
+        giving a voice to the powerless and holding power to account. Our
+        independent ownership structure means we are entirely free from
+        political and commercial influence.{" "}
+        <span css={highlightedCss}>
+          Only our values determine the stories we choose to cover
+        </span>{" "}
+        – relentlessly and courageously.
+      </p>
+    </FullWidthText>
   </>
 );
 

--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -2,6 +2,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
 import React from "react";
+import FullWidthText from "../../components/fullWidthText";
 import { PageStyles } from "../../components/pageStyles";
 import Header from "../../components/header";
 
@@ -32,6 +33,17 @@ const JournalismPage = () => (
         },
       ]}
     />
+    <FullWidthText theme="dark" title="Journalism">
+      <p>
+        The Guardian has a global reputation of holding power to account and
+        championing the voices of those less heard. Our Covid-19 investigations
+        exposed governmental and social failings, as did our earlier work on the
+        Snowden disclosures, the Windrush scandal, Cambridge Analytica and the
+        Panama Papers. We are passionate about the climate emergency, social
+        justice, fairness and progress. We remain dedicated to truth and to
+        bringing about a more hopeful future.
+      </p>
+    </FullWidthText>
   </>
 );
 

--- a/src/pages/our-history/index.tsx
+++ b/src/pages/our-history/index.tsx
@@ -4,6 +4,7 @@ import { jsx } from "@emotion/react";
 import React from "react";
 import { PageStyles } from "../../components/pageStyles";
 import Header from "../../components/header";
+import FullWidthText from "../../components/fullWidthText";
 
 const OurHistory = () => (
   <>
@@ -32,6 +33,23 @@ const OurHistory = () => (
         },
       ]}
     />
+    <FullWidthText theme="dark" title="Our History">
+      <>
+        <p>
+          The Manchester Guardian was founded to promote the liberal interest in
+          the aftermath of the 1819 Peterloo Massacre, and was first published
+          on 5 May 1821. The Guardian achieved national and international
+          recognition under the editorship of CP Scott, who held the post for 57
+          years from 1872.
+        </p>
+        <p>
+          In May 1921, CP Scott wrote a leading article to mark the centenary of
+          the paper setting out the values of the Guardian: honesty, cleanness
+          [integrity], courage, fairness, a sense of duty to the reader and a
+          sense of duty to the community.
+        </p>
+      </>
+    </FullWidthText>
   </>
 );
 

--- a/src/pages/our-organisation/index.tsx
+++ b/src/pages/our-organisation/index.tsx
@@ -2,6 +2,7 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
 import React from "react";
+import FullWidthText from "../../components/fullWidthText";
 import Header from "../../components/header";
 import { PageStyles } from "../../components/pageStyles";
 
@@ -32,6 +33,19 @@ const HomePage = () => (
         },
       ]}
     />
+    <FullWidthText theme="dark" title="Our organisation">
+      <>
+        <p>
+          Guardian Media Group has only one shareholder - The Scott Trust. The
+          Trust forms part of a unique ownership structure for the Guardian that
+          ensures editorial interests remain free of commercial pressures.
+        </p>
+        <p>
+          Today more than half of our revenue comes directly from our readers,
+          helping to support Guardian journalism and keep it open for everyone.
+        </p>
+      </>
+    </FullWidthText>
   </>
 );
 


### PR DESCRIPTION
## What does this change?
Create full width text component with a choice of dark and light themes, an optional title and the ability to highlight text within the main body

## Images
| Mobile | Tablet | Desktop  | Wide |
| ------------- | ------------- | ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/114737549-09550780-9d3f-11eb-9bac-8c587360b61c.png) | ![image](https://user-images.githubusercontent.com/44685872/114737612-1a9e1400-9d3f-11eb-86cd-36cc42b1b005.png) | ![image](https://user-images.githubusercontent.com/44685872/114737735-36091f00-9d3f-11eb-8a09-a4ce94c661d2.png) | ![image](https://user-images.githubusercontent.com/44685872/114737806-47eac200-9d3f-11eb-8619-a0d4d7310924.png) |
| ![image](https://user-images.githubusercontent.com/44685872/114737881-5933ce80-9d3f-11eb-8bde-c395e0c8621c.png) | ![image](https://user-images.githubusercontent.com/44685872/114737925-63ee6380-9d3f-11eb-9b36-62af0b852431.png) | ![image](https://user-images.githubusercontent.com/44685872/114738000-749ed980-9d3f-11eb-9c5c-a208d0120495.png) | ![image](https://user-images.githubusercontent.com/44685872/114738050-81bbc880-9d3f-11eb-9934-dd1ea9f9e117.png) |