### PR TITLE
Header quote alignment

### DIFF
--- a/src/components/headerQuote.tsx
+++ b/src/components/headerQuote.tsx
@@ -41,7 +41,7 @@ const triangleCss = css`
   }
   ${minWidth.wide} {
     left: 50%;
-    left: calc(50% - 320px);
+    left: calc(50% - 393px);
   }
 `;
 

--- a/src/components/headerQuote.tsx
+++ b/src/components/headerQuote.tsx
@@ -47,7 +47,7 @@ const triangleCss = css`
 
 const blockquoteCss = css`
   display: inline;
-  margin-left: 0;
+  margin: 0;
   ${titlepiece.small()};
   font-size: 36px;
   line-height: 1.15;
@@ -77,7 +77,7 @@ const quotationMarkCss = css`
   ${minWidth.wide} {
     height: 55px;
     position: absolute;
-    left: 235px;
+    left: 160px;
     top: 110px;
   }
 `;
@@ -85,13 +85,13 @@ const quotationMarkCss = css`
 const quoteDivCss = css`
   padding: 27px ${space[6]}px;
   ${minWidth.tablet} {
-    padding: 45px 140px;
+    padding: 45px 141px;
   }
   ${minWidth.desktop} {
-    padding: 95px 100px;
+    padding: 95px 101px;
   }
   ${minWidth.wide} {
-    padding: 95px 170px 95px 330px;
+    padding: 95px 95px 95px 259px;
     position: relative;
   }
 `;


### PR DESCRIPTION
## What does this change?
minor alignment amends to the header quote component

## Images
Before/After:
<p float="left">
  <img align="top" src="https://user-images.githubusercontent.com/2510683/114899781-2bb45700-9e0b-11eb-8f18-cabb68b6030a.png" width="48%" />
  <img align="top" src="https://user-images.githubusercontent.com/2510683/114900568-e5132c80-9e0b-11eb-91d3-5f2d8c1dc630.png" width="48%" /> 
</p>

