### PR TITLE
[RB] - remove the dark mobile overlay from obscuring the dom when the menu is closed

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -42,12 +42,12 @@ const headerStyles = css`
       position: absolute;
       top: 0;
       left: 100%;
-      width: 100vw;
+      width: 0;
       height: 100vh;
       background-color: black;
       overflow-x: hidden;
       opacity: 0;
-      transition: opacity 0.4s ${cssTransitionFunc};
+      transition: opacity 0.4s ${cssTransitionFunc}, width 0.4s ${cssTransitionFunc};
       }
     &:after {
       content: "";
@@ -67,6 +67,7 @@ const headerStyles = css`
 
   & input:checked ~ .top-and-bottom-nav:before {
     opacity: 0.8;
+    width: 100vw;
   }
 
   & nav {


### PR DESCRIPTION
## What does this change?
On mobile breakpoints when the navigation is open then behind the nav to the left where there is a gap there is an 80% opacity element there to 'fade out' the background page.

This pr adds the width property on top of the opacity property to the transition css properties for this element and subsequently transitions the elements width to 0 when the menu is closed so that is doesn't obscure the users interaction with the page.

![menu-open](https://user-images.githubusercontent.com/2510683/115404287-16617300-a1e5-11eb-8334-11133c3bff98.png)
