### PR TITLE
Create contact/work for us component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,10 +137,38 @@
         "yargs": "^15.1.0"
       }
     },
+    "@guardian/src-button": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/src-button/-/src-button-3.5.0.tgz",
+      "integrity": "sha512-FFL4VZn/wKiJWEdGx7xee6Nw5sta3UWGjFqjVhQeLbriWZqOWhr/OOIFpX5Rx4h8j3lUtLkfCm6FP9chlzDbRQ==",
+      "requires": {
+        "@guardian/src-helpers": "^3.5.0"
+      }
+    },
     "@guardian/src-foundations": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-3.3.0.tgz",
       "integrity": "sha512-ephhrEZ2aDQYkc4FM5g1OQju5C2oMS/QCRaSUw58SHNsU1br0Sh3q/KUaTsxO/aJrtk2w9oRMqX2EceRsDdz5Q=="
+    },
+    "@guardian/src-helpers": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/src-helpers/-/src-helpers-3.5.0.tgz",
+      "integrity": "sha512-6fav708zODa0fkhlj67k8xdu4MAEQUaUgj8HjIYFU6qiohZI6cS57U5RrQlXV5BYAhz6vts9/EMzjawxV5IHcA==",
+      "requires": {
+        "@guardian/src-foundations": "^3.5.0"
+      },
+      "dependencies": {
+        "@guardian/src-foundations": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/@guardian/src-foundations/-/src-foundations-3.5.0.tgz",
+          "integrity": "sha512-Xx5kq1bJLKpghBRnFjzKAfnZsWcP76aQfTf7sA1hgq61o/CXHYTTL2iv3AF186zvxEMZ1oZ+Xo0E8TvzX1aLBQ=="
+        }
+      }
+    },
+    "@guardian/src-icons": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@guardian/src-icons/-/src-icons-3.5.0.tgz",
+      "integrity": "sha512-EFAadkgRrNP1SY1b6k8E68VMfqbYNAVILe9w4V+4sbM+wdigRwJ0x54Md/dPHF4ORNvMKt72YutybSDeuhYh1A=="
     },
     "@hapi/accept": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "homepage": "https://github.com/guardian/about-us#readme",
   "dependencies": {
     "@emotion/react": "^11.1.5",
+    "@guardian/src-button": "^3.5.0",
     "@guardian/src-foundations": "^3.3.0",
+    "@guardian/src-icons": "^3.5.0",
     "next": "^10.0.8",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"

--- a/src/components/contactAndWorkForUs.tsx
+++ b/src/components/contactAndWorkForUs.tsx
@@ -2,10 +2,10 @@
 /** @jsx jsx */
 import { background, brand, neutral, space } from "@guardian/src-foundations";
 import { body, headline } from "@guardian/src-foundations/typography";
-import { LinkButton } from "@guardian/src-button";
-import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { css, jsx } from "@emotion/react";
-import { minWidth } from "../styles/breakpoints";
+import { LinkButton } from "@guardian/src-button";
+import { minWidth, namedBreakpoints } from "../styles/breakpoints";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
 
 const divCss = css`
   width: 100%;
@@ -63,13 +63,19 @@ const contactAndWorkForUsCss = css`
   padding: 46px ${space[5]}px ${space[6]}px;
   ${minWidth.tablet} {
     flex-direction: row;
-    padding: ${space[12]}px 140px 34px;
+    padding: ${space[12]}px ${space[5]}px 34px;
+    margin: 0 auto;
+    width: ${namedBreakpoints.tablet}px;
   }
   ${minWidth.desktop} {
-    padding: 58px 100px 74px;
+    padding: 58px 80px 74px;
+    margin: 0 auto;
+    width: ${namedBreakpoints.desktop}px;
   }
   ${minWidth.wide} {
-    padding: 72px 259px ${space[24]}px;
+    padding: 72px 239px ${space[24]}px;
+    margin: 0 auto;
+    width: ${namedBreakpoints.wide}px;
   }
 `;
 

--- a/src/components/contactAndWorkForUs.tsx
+++ b/src/components/contactAndWorkForUs.tsx
@@ -1,0 +1,95 @@
+/** @jsxRuntime classic /
+/** @jsx jsx */
+import { background, brand, neutral, space } from "@guardian/src-foundations";
+import { body, headline } from "@guardian/src-foundations/typography";
+import { LinkButton } from "@guardian/src-button";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
+import { css, jsx } from "@emotion/react";
+import { minWidth } from "../styles/breakpoints";
+
+const divCss = css`
+  width: 100%;
+  border-top: 1px solid ${neutral[86]};
+  margin-bottom: ${space[9]}px;
+  ${minWidth.tablet} {
+    width: 220px;
+    margin-right: ${space[5]}px;
+  }
+`;
+
+const h3Css = css`
+  color: ${brand[400]};
+  ${headline.xsmall({ fontWeight: "bold" })};
+  margin: 0;
+`;
+
+const pCss = css`
+  ${body.medium({ fontWeight: "regular" })}
+  color: ${neutral[7]};
+`;
+
+interface ContactSectionProps {
+  title: string;
+  body: string;
+  href: string;
+}
+
+const ContactSection = (props: ContactSectionProps) => (
+  <div css={divCss}>
+    <h3 css={h3Css}>{props.title}</h3>
+    <p css={pCss}>{props.body}</p>
+    <LinkButton
+      priority="tertiary"
+      size="small"
+      icon={<SvgArrowRightStraight />}
+      iconSide="right"
+      nudgeIcon={true}
+      href={props.href}
+    >
+      {props.title}
+    </LinkButton>
+  </div>
+);
+
+const containerCss = css`
+  background-color: ${background.primary};
+`;
+
+const contactAndWorkForUsCss = css`
+  display: flex;
+  flex-direction: column;
+  max-width: 1300px;
+  margin: 0 auto;
+  padding: 46px ${space[5]}px ${space[6]}px;
+  ${minWidth.tablet} {
+    flex-direction: row;
+    padding: ${space[12]}px 140px 34px;
+  }
+  ${minWidth.desktop} {
+    padding: 58px 100px 74px;
+  }
+  ${minWidth.wide} {
+    padding: 72px 259px ${space[24]}px;
+  }
+`;
+
+const ContactAndWorkForUs = () => {
+  return (
+    <div css={containerCss}>
+      <div css={contactAndWorkForUsCss}>
+        <ContactSection
+          title="Contact us"
+          body="Find out how to get in touch with The Guardian."
+          href="https://www.theguardian.com/help/contact-us"
+        />
+        <ContactSection
+          title="Work for us"
+          body="Search for jobs at The Guardian and apply. "
+          href="https://workforus.theguardian.com/"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ContactAndWorkForUs;

--- a/src/components/contactAndWorkForUs.tsx
+++ b/src/components/contactAndWorkForUs.tsx
@@ -2,12 +2,13 @@
 /** @jsx jsx */
 import { background, brand, neutral, space } from "@guardian/src-foundations";
 import { body, headline } from "@guardian/src-foundations/typography";
+import { containerCss } from "../styles/sharedStyles";
 import { css, jsx } from "@emotion/react";
 import { LinkButton } from "@guardian/src-button";
 import { minWidth, namedBreakpoints } from "../styles/breakpoints";
 import { SvgArrowRightStraight } from "@guardian/src-icons";
 
-const divCss = css`
+const contactSectionItemCss = css`
   width: 100%;
   border-top: 1px solid ${neutral[86]};
   margin-bottom: ${space[9]}px;
@@ -17,27 +18,27 @@ const divCss = css`
   }
 `;
 
-const h3Css = css`
+const contactSectionItemH3Css = css`
   color: ${brand[400]};
   ${headline.xsmall({ fontWeight: "bold" })};
   margin: 0;
 `;
 
-const pCss = css`
-  ${body.medium({ fontWeight: "regular" })}
+const contactSectionItemPCss = css`
+  ${body.medium({ fontWeight: "regular" })};
   color: ${neutral[7]};
 `;
 
-interface ContactSectionProps {
+interface ContactSectionItemProps {
   title: string;
   body: string;
   href: string;
 }
 
-const ContactSection = (props: ContactSectionProps) => (
-  <div css={divCss}>
-    <h3 css={h3Css}>{props.title}</h3>
-    <p css={pCss}>{props.body}</p>
+const ContactSectionItem = (props: ContactSectionItemProps) => (
+  <div css={contactSectionItemCss}>
+    <h3 css={contactSectionItemH3Css}>{props.title}</h3>
+    <p css={contactSectionItemPCss}>{props.body}</p>
     <LinkButton
       priority="tertiary"
       size="small"
@@ -51,10 +52,6 @@ const ContactSection = (props: ContactSectionProps) => (
   </div>
 );
 
-const containerCss = css`
-  background-color: ${background.primary};
-`;
-
 const contactAndWorkForUsCss = css`
   display: flex;
   flex-direction: column;
@@ -64,31 +61,28 @@ const contactAndWorkForUsCss = css`
   ${minWidth.tablet} {
     flex-direction: row;
     padding: ${space[12]}px ${space[5]}px 34px;
-    margin: 0 auto;
     width: ${namedBreakpoints.tablet}px;
   }
   ${minWidth.desktop} {
     padding: 58px 80px 74px;
-    margin: 0 auto;
     width: ${namedBreakpoints.desktop}px;
   }
   ${minWidth.wide} {
     padding: 72px 239px ${space[24]}px;
-    margin: 0 auto;
     width: ${namedBreakpoints.wide}px;
   }
 `;
 
 const ContactAndWorkForUs = () => {
   return (
-    <div css={containerCss}>
+    <div css={containerCss(background.primary)}>
       <div css={contactAndWorkForUsCss}>
-        <ContactSection
+        <ContactSectionItem
           title="Contact us"
           body="Find out how to get in touch with The Guardian."
           href="https://www.theguardian.com/help/contact-us"
         />
-        <ContactSection
+        <ContactSectionItem
           title="Work for us"
           body="Search for jobs at The Guardian and apply. "
           href="https://workforus.theguardian.com/"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,13 +2,14 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
 import React from "react";
-import FullWidthText, { highlightedCss } from "../components/fullWidthText";
-import HeaderQuote from "../components/headerQuote";
-import { PageStyles } from "../components/pageStyles";
-import Header from "../components/header";
 import BoxContainer from "../components/boxContainer";
+import ContactAndWorkForUs from "../components/contactAndWorkForUs";
+import FullWidthText, { highlightedCss } from "../components/fullWidthText";
+import Header from "../components/header";
+import HeaderQuote from "../components/headerQuote";
 import InnerText from "../components/innerText";
 import { neutral } from "@guardian/src-foundations";
+import { PageStyles } from "../components/pageStyles";
 
 const HomePage = () => (
   <>
@@ -125,6 +126,7 @@ const HomePage = () => (
         </>
       </InnerText>
     </BoxContainer>
+    <ContactAndWorkForUs />
   </>
 );
 

--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -2,13 +2,14 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
 import React from "react";
-import FullWidthText from "../../components/fullWidthText";
-import { PageStyles } from "../../components/pageStyles";
-import Header from "../../components/header";
 import BoxContainer from "../../components/boxContainer";
+import ContactAndWorkForUs from "../../components/contactAndWorkForUs";
+import FullWidthText from "../../components/fullWidthText";
+import Header from "../../components/header";
+import { headingCss } from "../../styles/sharedStyles";
 import InnerText from "../../components/innerText";
 import { neutral } from "@guardian/src-foundations";
-import { headingCss } from "../../styles/sharedStyles";
+import { PageStyles } from "../../components/pageStyles";
 
 const JournalismPage = () => (
   <>
@@ -100,6 +101,7 @@ const JournalismPage = () => (
         </p>
       </InnerText>
     </BoxContainer>
+    <ContactAndWorkForUs />
   </>
 );
 

--- a/src/pages/our-history/index.tsx
+++ b/src/pages/our-history/index.tsx
@@ -2,12 +2,13 @@
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
 import React from "react";
-import { PageStyles } from "../../components/pageStyles";
-import Header from "../../components/header";
-import FullWidthText from "../../components/fullWidthText";
 import BoxContainer from "../../components/boxContainer";
-import { neutral } from "@guardian/src-foundations/palette";
+import ContactAndWorkForUs from "../../components/contactAndWorkForUs";
+import FullWidthText from "../../components/fullWidthText";
+import Header from "../../components/header";
+import { PageStyles } from "../../components/pageStyles";
 import { headingCss } from "../../styles/sharedStyles";
+import { neutral } from "@guardian/src-foundations/palette";
 
 const OurHistory = () => (
   <>
@@ -65,6 +66,7 @@ const OurHistory = () => (
     >
       <h2 css={headingCss}>The Scott Trust</h2>
     </BoxContainer>
+    <ContactAndWorkForUs />
   </>
 );
 

--- a/src/pages/our-organisation/index.tsx
+++ b/src/pages/our-organisation/index.tsx
@@ -1,16 +1,17 @@
 /** @jsxRuntime classic /
 /** @jsx jsx */
 import { jsx } from "@emotion/react";
-import { brand, neutral } from "@guardian/src-foundations";
 import React from "react";
 import BoxContainer, {
   boxContainerPadding,
 } from "../../components/boxContainer";
+import { brand, neutral } from "@guardian/src-foundations";
+import ContactAndWorkForUs from "../../components/contactAndWorkForUs";
 import FullWidthText from "../../components/fullWidthText";
 import Header from "../../components/header";
+import { headingCss } from "../../styles/sharedStyles";
 import InnerText from "../../components/innerText";
 import { PageStyles } from "../../components/pageStyles";
-import { headingCss } from "../../styles/sharedStyles";
 
 // placeholder values for the background gradient until values are agreed upon for each breakpoint
 const ourStructureBkg = {
@@ -143,6 +144,7 @@ const HomePage = () => (
         </p>
       </InnerText>
     </BoxContainer>
+    <ContactAndWorkForUs />
   </>
 );
 


### PR DESCRIPTION
## What does this change?
Create the contact/work for us component and add it to all of the about us pages. The component contains a sub-component consisting of a title, text body and button. 

This sub component is then used to construct the contact/work for us section with the correct margin and paddings for different breakpoints.

## Images
| Mobile  | Tablet | Desktop | Wide |
| ------------- | ------------- | ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/115547072-bda1e100-a29d-11eb-9f2e-2e4d9cd2940d.png)| ![image](https://user-images.githubusercontent.com/44685872/115547114-cabed000-a29d-11eb-8150-5b016a7dfc29.png) | ![image](https://user-images.githubusercontent.com/44685872/115547314-0a85b780-a29e-11eb-92f4-ce76b01f4508.png) | ![image](https://user-images.githubusercontent.com/44685872/115547229-f641ba80-a29d-11eb-99ed-6cc79251d49f.png) | 
