### PR TITLE
Footer

### DIFF
--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -249,7 +249,7 @@ export const Footer = () => {
                         css={css`
                           padding: 0 14px;
                         `}
-                        href=""
+                        href="https://support.theguardian.com/uk/contribute"
                       >
                         Contribute
                       </LinkButton>
@@ -262,7 +262,7 @@ export const Footer = () => {
                       css={css`
                         padding: 0 14px;
                       `}
-                      href=""
+                      href="https://support.theguardian.com/uk/subscribe"
                     >
                       Subscribe
                     </LinkButton>

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -1,0 +1,295 @@
+/** @jsxRuntime classic /
+/** @jsx jsx */
+import { brand, brandAlt, neutral } from "@guardian/src-foundations";
+import { footerLinks } from "./footerlinks";
+import { from } from "@guardian/src-foundations/mq";
+import { headline, textSans } from "@guardian/src-foundations/typography";
+import { LinkButton, buttonReaderRevenue } from "@guardian/src-button";
+import { SvgArrowRightStraight } from "@guardian/src-icons";
+import { SyntheticEvent } from "react";
+import { ThemeProvider, css, jsx } from "@emotion/react";
+
+const TODAY = new Date();
+
+const footerColourStyles = css`
+  background-color: ${brand[400]};
+  color: ${neutral[100]};
+`;
+
+const footerSizeStyles = css`
+  max-width: 1300px;
+  margin: auto;
+`;
+
+const footerContentStyles = css`
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-top: 0;
+
+  ${from.desktop} {
+    padding: 0 20px;
+    margin: 0 20px;
+  }
+
+  ${from.leftCol} {
+    display: flex;
+  }
+`;
+
+const emailSignUpStyles = css`
+  padding: 0;
+  border: 0;
+  width: 100%;
+  margin: 0;
+  ${from.leftCol} {
+    width: 340px;
+  }
+  ${from.wide} {
+    width: 460px;
+  }
+`;
+
+const emailSignUpIframeStyles = css`
+  min-height: 150px;
+`;
+
+const footerMenuStyles = css`
+  font-feature-settings: kern;
+  font-size: 16px;
+  line-height: 16px;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding-bottom: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  ${from.wide} {
+    border-top: 0;
+  }
+`;
+
+const footerMenuUlStyles = css`
+  line-height: 19.2px;
+  width: calc(50% - 1.25rem - 1px);
+  list-style: none;
+  position: relative;
+  padding: 0 10px;
+  margin: 0;
+
+  &:nth-of-type(even) {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+
+  ${from.tablet} {
+    &:not(:first-of-type) {
+      border-left: 1px solid rgba(255, 255, 255, 0.3);
+    }
+
+    width: 161px;
+    flex: 1 0 0;
+  }
+
+  ${from.desktop} {
+    border-left: 1px solid rgba(255, 255, 255, 0.3);
+  }
+`;
+
+const footerMenuLiStyles = css`
+  list-style: none;
+`;
+
+const footerLinkStyles = css`
+  display: inline-block;
+  padding: 6px 0;
+  color: ${neutral[100]};
+  ${textSans.medium()};
+  font-size: 16px;
+  line-height: 19.2px;
+  text-decoration: none;
+  :hover {
+    color: ${brandAlt[400]};
+    cursor: pointer;
+  }
+`;
+
+const supportStyles = css`
+  width: 50%;
+  border-left: 1px solid rgba(255, 255, 255, 0.3);
+  padding-left: 10px;
+  ${from.phablet} {
+    width: 300px;
+  }
+  border-top: 1px solid rgba(255, 255, 255, 0.3);
+  ${from.tablet} {
+    border-top: 0;
+  }
+`;
+
+const supportTitleStyles = css`
+  color: ${brandAlt[400]};
+  ${headline.xsmall({ fontWeight: "bold" })};
+  line-height: 24px;
+  margin-top: 3px;
+  margin-bottom: 12px;
+  ${from.phablet} {
+    font-size: 32px;
+    line-height: 32px;
+  }
+`;
+
+const supportButtonContainerStyles = css`
+  display: inline-block;
+  margin-right: 10px;
+  margin-bottom: 6px;
+`;
+
+const copyrightStyles = css`
+  padding-bottom: 24px;
+  padding-left: 20px;
+  padding-right: 20px;
+  position: relative;
+`;
+
+const backToTopLinkStyles = css`
+  font-size: 16px;
+  color: ${neutral[100]};
+  font-weight: bold;
+  padding: 0 5px;
+  background-color: ${brand[400]};
+  :hover {
+    color: ${brandAlt[400]};
+  }
+  position: absolute;
+  right: 20px;
+  transform: translateY(-50%);
+`;
+
+const backToTopLabelStyles = css`
+  ${textSans.small({ fontWeight: "bold" })};
+  font-size: 16px;
+  display: inline-block;
+  padding-right: 5px;
+  padding-top: 9px;
+`;
+
+const backToTopButtonOutterContainerStyles = css`
+  position: relative;
+  float: right;
+  background-color: currentColor;
+  border-radius: 100%;
+  height: 42px;
+  width: 42px;
+`;
+
+const backToTopButtonInnerContainerStyles = css`
+  position: absolute;
+  fill: ${brand[400]};
+  top: 9px;
+  left: 9px;
+`;
+
+const copyrightTextStyles = css`
+  ${textSans.xsmall()};
+
+  ${from.tablet} {
+    padding-top: 6px;
+  }
+  padding-top: 26px;
+  font-size: 12px;
+`;
+
+const fillEmailSignup = (_: SyntheticEvent<HTMLIFrameElement>) => {
+  // Placeholder method to autofill user email when the iframe is hosted on the same hostname
+  return;
+};
+
+export const Footer = () => {
+  return (
+    <footer>
+      <div>
+        <div css={footerColourStyles}>
+          <div css={footerSizeStyles}>
+            <div css={footerContentStyles}>
+              <div css={emailSignUpStyles}>
+                <iframe
+                  title="Guardian Email Sign-up Form"
+                  src={`https://www.theguardian.com/email/form/footer/today-uk`}
+                  scrolling="no"
+                  seamless={false}
+                  frameBorder="0"
+                  data-form-success-desc="We will send you our picks of the most important headlines tomorrow morning."
+                  data-node-uid="2"
+                  height="86px"
+                  onLoad={(emailForm) => fillEmailSignup(emailForm)}
+                  css={emailSignUpIframeStyles}
+                />
+              </div>
+
+              <div css={footerMenuStyles}>
+                {footerLinks.map((linkList, i) => (
+                  <ul key={i} css={footerMenuUlStyles}>
+                    {linkList.map(({ title, link }) => (
+                      <li key={title} css={footerMenuLiStyles}>
+                        <a href={link} css={footerLinkStyles}>
+                          {title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                ))}
+
+                <div css={supportStyles}>
+                  <div css={supportTitleStyles}>Support The&nbsp;Guardian</div>
+                  <ThemeProvider theme={buttonReaderRevenue}>
+                    <div css={supportButtonContainerStyles}>
+                      <LinkButton
+                        iconSide="right"
+                        icon={<SvgArrowRightStraight />}
+                        nudgeIcon={true}
+                        size="small"
+                        css={css`
+                          padding: 0 14px;
+                        `}
+                        href=""
+                      >
+                        Contribute
+                      </LinkButton>
+                    </div>
+                    <LinkButton
+                      iconSide="right"
+                      icon={<SvgArrowRightStraight />}
+                      nudgeIcon={true}
+                      size="small"
+                      css={css`
+                        padding: 0 14px;
+                      `}
+                      href=""
+                    >
+                      Subscribe
+                    </LinkButton>
+                  </ThemeProvider>
+                </div>
+              </div>
+            </div>
+
+            <div css={copyrightStyles}>
+              <a href="#top" css={backToTopLinkStyles}>
+                <span css={backToTopLabelStyles}>Back to top</span>
+                <span css={backToTopButtonOutterContainerStyles}>
+                  <span css={backToTopButtonInnerContainerStyles}>
+                    <svg width="24" height="18" viewBox="0 0 24 18">
+                      <path d="M.4 15.3l10.5-8.4L12 6l1.1.9 10.5 8.4-.5.7L12 9.7.9 16l-.5-.7z" />
+                    </svg>
+                  </span>
+                </span>
+              </a>
+              <div css={copyrightTextStyles}>
+                © {TODAY.getFullYear()} Guardian News and Media Limited or its
+                affiliated companies. All&nbsp;rights&nbsp;reserved.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};

--- a/src/components/footer/footerlinks.tsx
+++ b/src/components/footer/footerlinks.tsx
@@ -1,0 +1,118 @@
+interface FooterLink {
+  title: string;
+  // titleUSA?: string;
+  link?: string;
+  // cmp?: boolean;
+}
+
+const domain = "theguardian.com";
+
+export const footerLinks: FooterLink[][] = [
+  [
+    {
+      title: "About us",
+      link: `https://${domain}/about`,
+    },
+    {
+      title: "Contact us",
+      link: `https://${domain}/help/contact-us`,
+    },
+    {
+      title: "Complaints & corrections",
+      link: `https://${domain}/info/complaints-and-corrections`,
+    },
+    {
+      title: "Secure Drop",
+      link: `https://${domain}/securedrop`,
+    },
+    {
+      title: "Work for us",
+      link: `https://workforus.${domain}`,
+    },
+    // {
+    //   title: "Privacy settings",
+    //   titleUSA: "California resident – Do Not Sell",
+    //   cmp: true,
+    // },
+    {
+      title: "Privacy policy",
+      link: `https://${domain}/info/privacy`,
+    },
+    {
+      title: "Cookie policy",
+      link: `https://${domain}/info/cookies`,
+    },
+    {
+      title: "Terms & conditions",
+      link: `https://www.${domain}/help/terms-of-service`,
+    },
+    {
+      title: "Help",
+      link: `https://www.${domain}/help`,
+    },
+  ],
+  [
+    {
+      title: "All topics",
+      link: `https://${domain}/index/subjects/a`,
+    },
+    {
+      title: "All writers",
+      link: `https://${domain}/index/contributors`,
+    },
+    {
+      title: "Modern Slavery Act",
+      link: `https://${domain}/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT`,
+    },
+    {
+      title: "Digital newspaper archive",
+      link: `https://theguardian.newspapers.com/`,
+    },
+    {
+      title: "Facebook",
+      link: `https://www.facebook.com/theguardian`,
+    },
+    {
+      title: "YouTube",
+      link: `https://www.youtube.com/user/TheGuardian`,
+    },
+    {
+      title: "Instagram",
+      link: `https://www.instagram.com/guardian`,
+    },
+    {
+      title: "LinkedIn",
+      link: `https://www.linkedin.com/company/theguardian`,
+    },
+    {
+      title: "Twitter",
+      link: `https://twitter.com/guardian`,
+    },
+    {
+      title: "Newsletters",
+      link: `https://www.theguardian.com/email-newsletters?INTCMP=DOTCOM_FOOTER_NEWSLETTER_UK`,
+    },
+  ],
+  [
+    {
+      title: "Advertise with us",
+      link: `https://advertising.${domain}`,
+    },
+    {
+      title: "Guardian Labs",
+      link: `https://${domain}/guardian-labs`,
+    },
+    {
+      title: "Search jobs",
+      link: `https://jobs.${domain}/?INTCMP=NGW_FOOTER_UK_GU_JOBS`,
+    },
+    {
+      title: "Dating",
+      link: `https://soulmates.${domain}/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES`,
+    },
+    {
+      title: "Patrons",
+      link: `https://patrons.${domain}/?INTCMP=footer_patrons`,
+    },
+  ],
+];

--- a/src/components/footer/footerlinks.tsx
+++ b/src/components/footer/footerlinks.tsx
@@ -29,11 +29,11 @@ export const footerLinks: FooterLink[][] = [
       title: "Work for us",
       link: `https://workforus.${domain}`,
     },
-    // {
-    //   title: "Privacy settings",
-    //   titleUSA: "California resident – Do Not Sell",
-    //   cmp: true,
-    // },
+    {
+      title: "Privacy settings",
+      //   titleUSA: "California resident – Do Not Sell",
+      //   cmp: true,
+    },
     {
       title: "Privacy policy",
       link: `https://${domain}/info/privacy`,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,7 @@ import { jsx } from "@emotion/react";
 import React from "react";
 import BoxContainer from "../components/boxContainer";
 import ContactAndWorkForUs from "../components/contactAndWorkForUs";
+import { Footer } from "../components/footer/footer";
 import FullWidthText, { highlightedCss } from "../components/fullWidthText";
 import Header from "../components/header";
 import HeaderQuote from "../components/headerQuote";
@@ -127,6 +128,7 @@ const HomePage = () => (
       </InnerText>
     </BoxContainer>
     <ContactAndWorkForUs />
+    <Footer />
   </>
 );
 

--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -4,6 +4,7 @@ import { jsx } from "@emotion/react";
 import React from "react";
 import BoxContainer from "../../components/boxContainer";
 import ContactAndWorkForUs from "../../components/contactAndWorkForUs";
+import { Footer } from "../../components/footer/footer";
 import FullWidthText from "../../components/fullWidthText";
 import Header from "../../components/header";
 import { headingCss } from "../../styles/sharedStyles";
@@ -102,6 +103,7 @@ const JournalismPage = () => (
       </InnerText>
     </BoxContainer>
     <ContactAndWorkForUs />
+    <Footer />
   </>
 );
 

--- a/src/pages/our-history/index.tsx
+++ b/src/pages/our-history/index.tsx
@@ -4,6 +4,7 @@ import { jsx } from "@emotion/react";
 import React from "react";
 import BoxContainer from "../../components/boxContainer";
 import ContactAndWorkForUs from "../../components/contactAndWorkForUs";
+import { Footer } from "../../components/footer/footer";
 import FullWidthText from "../../components/fullWidthText";
 import Header from "../../components/header";
 import { PageStyles } from "../../components/pageStyles";
@@ -67,6 +68,7 @@ const OurHistory = () => (
       <h2 css={headingCss}>The Scott Trust</h2>
     </BoxContainer>
     <ContactAndWorkForUs />
+    <Footer />
   </>
 );
 

--- a/src/pages/our-organisation/index.tsx
+++ b/src/pages/our-organisation/index.tsx
@@ -7,6 +7,7 @@ import BoxContainer, {
 } from "../../components/boxContainer";
 import { brand, neutral } from "@guardian/src-foundations";
 import ContactAndWorkForUs from "../../components/contactAndWorkForUs";
+import { Footer } from "../../components/footer/footer";
 import FullWidthText from "../../components/fullWidthText";
 import Header from "../../components/header";
 import { headingCss } from "../../styles/sharedStyles";
@@ -145,6 +146,7 @@ const HomePage = () => (
       </InnerText>
     </BoxContainer>
     <ContactAndWorkForUs />
+    <Footer />
   </>
 );
 


### PR DESCRIPTION
## What does this change?
Add the footer to all of the "about-us" pages. The footer is based on the one used in manage-frontend though the actual links are based on the ones used in dotcom. 

Currently static, cmp will be incorporated in due course.

## Images
| Desktop  | Mobile |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/115693378-c525c080-a357-11eb-9aa1-64a3266f27f3.png) | ![image](https://user-images.githubusercontent.com/44685872/115693340-bb9c5880-a357-11eb-89f8-ccebdf154e4a.png)|