### PR TITLE
Organisation sustainability layout update

### DIFF
--- a/src/pages/our-organisation/index.tsx
+++ b/src/pages/our-organisation/index.tsx
@@ -186,7 +186,7 @@ const HomePage = () => (
             </p>
           </>
         </InnerText>
-        <div css={threeColumnResponsiveCardHolder}>
+        <div css={twoColumnResponsiveCardHolder}>
           <ResponsiveCardVariant1
             title="GMG as a B Corporation"
             imagePath="/images/organisation-11.png"
@@ -195,11 +195,6 @@ const HomePage = () => (
           <ResponsiveCardVariant1
             title="Our climate pledge"
             imagePath="/images/organisation-12.png"
-            linkUrl="https://www.theguardian.com/uk"
-          />
-          <ResponsiveCardVariant1
-            title="Sustainable business report"
-            imagePath="/images/organisation-13.png"
             linkUrl="https://www.theguardian.com/uk"
           />
         </div>


### PR DESCRIPTION
## What does this change?
The sustainability section of the our organisation page should have 2 items in it not 3

![sustainability-no](https://user-images.githubusercontent.com/2510683/116084108-5321e400-a695-11eb-9e69-01bf7092986c.png)


![sustainability-yes](https://user-images.githubusercontent.com/2510683/116084123-5917c500-a695-11eb-9b60-eb5fa2c92c6c.png)

