### PR TITLE
Last box container visual overlap fix

### DIFF
--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxRuntime classic /
 /** @jsx jsx */
-import { css, jsx } from "@emotion/react";
+import { jsx } from "@emotion/react";
 import React from "react";
 import BoxContainer from "../../components/boxContainer";
 import ContactAndWorkForUs from "../../components/contactAndWorkForUs";
@@ -14,12 +14,17 @@ import {
   headingCss,
   oneThenThreeColumnResponsiveCardHolder,
   responsiveCardV2Holder,
-  threeColumnResponsiveCardHolder,
   twoColumnResponsiveCardHolder,
 } from "../../styles/sharedStyles";
 import ResponsiveCardVariant1 from "../../components/responsiveCardVariant1";
 import FullWidthImage from "../../components/fullWidthImage";
 import ResponsiveCardVariant2 from "../../components/responsiveCardVariant2";
+
+const gotAStoryBkg = {
+  mobile: `linear-gradient(to top, ${neutral[100]} 42px, ${neutral[97]} 42px)`,
+  tablet: `linear-gradient(to top, ${neutral[100]} 49px, ${neutral[97]} 49px)`,
+  wide: `linear-gradient(to top, ${neutral[100]} 58px, ${neutral[97]} 58px)`,
+};
 
 const JournalismPage = () => (
   <>
@@ -59,7 +64,10 @@ const JournalismPage = () => (
         bringing about a more hopeful future.
       </p>
     </FullWidthText>
-    <FullWidthImage smallImageUrl="/images/journalism-full-width-small.png" largeImageUrl="/images/journalism-full-width-large.png" />
+    <FullWidthImage
+      smallImageUrl="/images/journalism-full-width-small.png"
+      largeImageUrl="/images/journalism-full-width-large.png"
+    />
     <BoxContainer
       theme="light"
       background={{ backgroundColor: `${neutral[97]}` }}
@@ -145,15 +153,51 @@ const JournalismPage = () => (
           </p>
         </InnerText>
         <div css={responsiveCardV2Holder}>
-          <ResponsiveCardVariant2 title="Website" href="https://www.theguardian.com" imageUrl="/images/journalism-9.png" />
-          <ResponsiveCardVariant2 title="Apps" href="https://www.theguardian.com" imageUrl="/images/journalism-10.png" />
-          <ResponsiveCardVariant2 title="Newsletters" href="https://www.theguardian.com" imageUrl="/images/journalism-11.png" />
-          <ResponsiveCardVariant2 title="The Guardian newspaper" href="https://www.theguardian.com" imageUrl="/images/journalism-12.png" />
-          <ResponsiveCardVariant2 title="The Observer newspaper" href="https://www.theguardian.com" imageUrl="/images/journalism-13.png" />
-          <ResponsiveCardVariant2 title="The Guardian Weekly" href="https://www.theguardian.com" imageUrl="/images/journalism-14.png" />
-          <ResponsiveCardVariant2 title="Podcasts" href="https://www.theguardian.com" imageUrl="/images/journalism-15.png" />
-          <ResponsiveCardVariant2 title="Video & documentaries" href="https://www.theguardian.com" imageUrl="/images/journalism-16.png" />
-          <ResponsiveCardVariant2 title="Live events" href="https://www.theguardian.com" imageUrl="/images/journalism-17.png" />
+          <ResponsiveCardVariant2
+            title="Website"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-9.png"
+          />
+          <ResponsiveCardVariant2
+            title="Apps"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-10.png"
+          />
+          <ResponsiveCardVariant2
+            title="Newsletters"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-11.png"
+          />
+          <ResponsiveCardVariant2
+            title="The Guardian newspaper"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-12.png"
+          />
+          <ResponsiveCardVariant2
+            title="The Observer newspaper"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-13.png"
+          />
+          <ResponsiveCardVariant2
+            title="The Guardian Weekly"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-14.png"
+          />
+          <ResponsiveCardVariant2
+            title="Podcasts"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-15.png"
+          />
+          <ResponsiveCardVariant2
+            title="Video & documentaries"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-16.png"
+          />
+          <ResponsiveCardVariant2
+            title="Live events"
+            href="https://www.theguardian.com"
+            imageUrl="/images/journalism-17.png"
+          />
         </div>
         <div css={twoColumnResponsiveCardHolder}>
           <h3>International editions</h3>
@@ -202,10 +246,7 @@ const JournalismPage = () => (
         </div>
       </>
     </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
+    <BoxContainer theme="light" background={gotAStoryBkg}>
       <>
         <InnerText title="Got a story?" theme="light">
           <p>

--- a/src/pages/our-history/index.tsx
+++ b/src/pages/our-history/index.tsx
@@ -16,6 +16,12 @@ import {
 import ResponsiveCardVariant1 from "../../components/responsiveCardVariant1";
 import FullWidthImage from "../../components/fullWidthImage";
 
+const scottTrustBkg = {
+  mobile: `linear-gradient(to top, ${neutral[100]} 42px, ${neutral[97]} 42px)`,
+  tablet: `linear-gradient(to top, ${neutral[100]} 49px, ${neutral[97]} 49px)`,
+  wide: `linear-gradient(to top, ${neutral[100]} 58px, ${neutral[97]} 58px)`,
+};
+
 const OurHistory = () => (
   <>
     <PageStyles />
@@ -60,7 +66,10 @@ const OurHistory = () => (
         </p>
       </>
     </FullWidthText>
-    <FullWidthImage smallImageUrl="/images/history-full-width-small.png" largeImageUrl="/images/history-full-width-large.png" />
+    <FullWidthImage
+      smallImageUrl="/images/history-full-width-small.png"
+      largeImageUrl="/images/history-full-width-large.png"
+    />
     <BoxContainer
       theme="light"
       background={{ backgroundColor: `${neutral[97]}` }}
@@ -88,10 +97,7 @@ const OurHistory = () => (
         </div>
       </>
     </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
+    <BoxContainer theme="light" background={scottTrustBkg}>
       <>
         <h2 css={headingCss}>The Scott Trust</h2>
         <div css={twoThenOneColumnResponsiveCardHolder}>

--- a/src/pages/our-organisation/index.tsx
+++ b/src/pages/our-organisation/index.tsx
@@ -26,7 +26,7 @@ import {
 } from "../../components/leadershipProfile";
 import { DetailsAndImage } from "../../components/detailsAndImage";
 
-// placeholder values for the background gradient until values are agreed upon for each breakpoint
+// placeholder values for the our structure and reports background gradients
 const ourStructureBkg = {
   mobile: `linear-gradient(to top, #052962 20px, ${neutral[97]} 20px)`,
   tablet: `linear-gradient(to top, #052962 20px, ${neutral[97]} 20px)`,
@@ -37,6 +37,12 @@ const reportsBkg = {
   mobile: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.mobile} - 20px), #052962 calc(100% - ${boxContainerPadding.mobile} - 20px))`,
   tablet: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 20px), #052962 calc(100% - ${boxContainerPadding.tablet} - 20px))`,
   wide: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.wide} - 20px), #052962 calc(100% - ${boxContainerPadding.wide} - 20px))`,
+};
+
+const guardianFoundationBkg = {
+  mobile: `linear-gradient(to top, ${neutral[100]} 42px, ${neutral[97]} 42px)`,
+  tablet: `linear-gradient(to top, ${neutral[100]} 49px, ${neutral[97]} 49px)`,
+  wide: `linear-gradient(to top, ${neutral[100]} 58px, ${neutral[97]} 58px)`,
 };
 
 const HomePage = () => (
@@ -276,10 +282,7 @@ const HomePage = () => (
         </div>
       </>
     </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
+    <BoxContainer theme="light" background={guardianFoundationBkg}>
       <>
         <InnerText title="Guardian Foundation" theme="light">
           <p>


### PR DESCRIPTION
## What does this change?
This adds a linear gradient background for the last box container on each relevant page which creates a visual "overlapping" as displayed in the images below.

## Images
| Mobile  | Tablet | Wide | 
| ------------- | ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/116097223-d9442780-a6a1-11eb-9945-e3a330518481.png) | ![image](https://user-images.githubusercontent.com/44685872/116097295-eeb95180-a6a1-11eb-959f-e72c1f3d8492.png) | ![image](https://user-images.githubusercontent.com/44685872/116097354-fbd64080-a6a1-11eb-9f45-092fc579085b.png) |