### PR TITLE
Update box container padding

### DIFF
--- a/src/components/boxContainer.tsx
+++ b/src/components/boxContainer.tsx
@@ -18,6 +18,7 @@ interface BoxContainerProps {
   children: ReactElement;
   background: Background;
   theme: Theme;
+  paddingBottom?: boolean;
 }
 
 export const boxContainerPadding = {
@@ -32,14 +33,23 @@ const BoxContainer = (props: BoxContainerProps) => {
       ? props.background.backgroundColor
       : props.background.mobile};
     padding-top: ${boxContainerPadding.mobile};
+    padding-bottom: ${props.paddingBottom
+      ? boxContainerPadding.mobile
+      : "none"};
     ${minWidth.tablet} {
       padding-top: ${boxContainerPadding.tablet};
+      padding-bottom: ${props.paddingBottom
+        ? boxContainerPadding.tablet
+        : "none"};
       background: ${props.background.backgroundColor
         ? props.background.backgroundColor
         : props.background.tablet};
     }
     ${minWidth.wide} {
       padding-top: ${boxContainerPadding.wide};
+      padding-bottom: ${props.paddingBottom
+        ? boxContainerPadding.wide
+        : "none"};
       background: ${props.background.backgroundColor
         ? props.background.backgroundColor
         : props.background.wide};

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -77,6 +77,7 @@ const HomePage = () => (
       theme="light"
       background={{ backgroundColor: `${neutral[97]}` }}
       overlapTop={true}
+      paddingBottom={true}
     >
       <>
         <InnerText title="Our Organisation" theme="light">
@@ -177,6 +178,7 @@ const HomePage = () => (
     <BoxContainer
       theme="light"
       background={{ backgroundColor: `${neutral[97]}` }}
+      paddingBottom={true}
     >
       <>
         <InnerText title="Journalism" theme="light">


### PR DESCRIPTION
## What does this change?
This adds an optional prop that can be passed to the box container to include padding on the bottom of the container.

This prop is then passed to the containers placed before the "latest news" and "G200 thrasher" components.

## Images
| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/116102656-cda72f80-a6a6-11eb-8531-6a3b17da5fb9.png) | ![image](https://user-images.githubusercontent.com/44685872/116102719-d7c92e00-a6a6-11eb-90e8-909dd4cf83d1.png) |
