### PR TITLE
fix: Enable RiffRaff to upload files to S3

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,3 +9,4 @@ deployments:
       bucket: gu-about-us
       prefixStack: false
       cacheControl: no-cache
+      publicReadAcl: false


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

The `gu-about-us` bucket is private and blocks public access with the default bucket rules. This means attempts to upload a file with a public ACL is rejected.

By default, RiffRaff will attempt to upload files to S3 with a public read ACL. This clashes with the bucket's policy and the deploy fails with a 403 response from S3.

In this change, we explicitly set the `publicReadAcl` RiffRaff config to false to instruct RiffRaff to upload without a public read ACL and thus comply with the bucket.

See:
  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html#access-control-block-public-access-options
  - https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Deploy this branch?

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Deploys work 🎉 .

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![image](https://user-images.githubusercontent.com/836140/116378627-39ee7400-a80a-11eb-974a-92590645cb32.png)

## Accessibility
<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

n/a

- [ ] [Tested with screen reader](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/558398)
- [ ] [Navigable with keyboard](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/39894d)
- [ ] [Colour contrast passed](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/92b913)
- [ ] [The change doesn't use only colour to convey meaning](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/29032f)
