### PR TITLE
[RB] - enable riffraff to deploy to s3.

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,3 +9,4 @@ deployments:
       bucket: gu-about-us
       prefixStack: false
       cacheControl: no-cache
+      publicReadAcl: false


### PR DESCRIPTION
## What does this change?
The `gu-about-us` bucket is private and blocks public access with the default bucket rules. This means attempts to upload a file with a public ACL is rejected.

By default, RiffRaff will attempt to upload files to S3 with a public read ACL. This clashes with the bucket's policy and the deploy fails with a 403 response from S3.

In this change, we explicitly set the `publicReadAcl` RiffRaff config to false to instruct RiffRaff to upload without a public read ACL and thus comply with the bucket.

See:
  - https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html#access-control-block-public-access-options
  - https://riffraff.gutools.co.uk/docs/magenta-lib/types#awss3


Already merged into main branch via the following: https://github.com/guardian/about-us/pull/33