### PR TITLE
Revert "fix: Enable RiffRaff to upload files to S3"

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -9,4 +9,3 @@ deployments:
       bucket: gu-about-us
       prefixStack: false
       cacheControl: no-cache
-      publicReadAcl: false


### PR DESCRIPTION
Reverts guardian/about-us#33

we need to revert this pr in order to make the bucket contents public :s