### PR TITLE
Update leadership background overlap values

### DIFF
--- a/src/components/boxContainer.tsx
+++ b/src/components/boxContainer.tsx
@@ -11,6 +11,7 @@ interface Background {
   backgroundColor?: string;
   mobile?: string;
   tablet?: string;
+  desktop?: string;
   wide?: string;
 }
 interface BoxContainerProps {
@@ -44,6 +45,11 @@ const BoxContainer = (props: BoxContainerProps) => {
       background: ${props.background.backgroundColor
         ? props.background.backgroundColor
         : props.background.tablet};
+    }
+    ${minWidth.desktop} {
+      background: ${props.background.backgroundColor
+        ? props.background.backgroundColor
+        : props.background.desktop};
     }
     ${minWidth.wide} {
       padding-top: ${boxContainerPadding.wide};

--- a/src/pages/our-organisation/index.tsx
+++ b/src/pages/our-organisation/index.tsx
@@ -28,16 +28,16 @@ import { DetailsAndImage } from "../../components/detailsAndImage";
 
 const ourStructureBkg = {
   mobile: `linear-gradient(to top, #052962 41px, ${neutral[97]} 41px)`,
-  tablet: `linear-gradient(to top, #052962 100px, ${neutral[97]} 100px)`,
-  desktop: `linear-gradient(to top, #052962 125px, ${neutral[97]} 125px)`,
-  wide: `linear-gradient(to top, #052962 125px, ${neutral[97]} 125px)`,
+  tablet: `linear-gradient(to top, #052962 80px, ${neutral[97]} 80px)`,
+  desktop: `linear-gradient(to top, #052962 90px, ${neutral[97]} 90px)`,
+  wide: `linear-gradient(to top, #052962 85px, ${neutral[97]} 85px)`,
 };
 
 const reportsBkg = {
   mobile: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.mobile} - 41px), #052962 calc(100% - ${boxContainerPadding.mobile} - 41px))`,
-  tablet: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 100px), #052962 calc(100% - ${boxContainerPadding.tablet} - 100px))`,
-  desktop: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 125px), #052962 calc(100% - ${boxContainerPadding.tablet} - 125px))`,
-  wide: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.wide} - 125px), #052962 calc(100% - ${boxContainerPadding.wide} - 125px))`,
+  tablet: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 80px), #052962 calc(100% - ${boxContainerPadding.tablet} - 80px))`,
+  desktop: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 90px), #052962 calc(100% - ${boxContainerPadding.tablet} - 90px))`,
+  wide: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.wide} - 85px), #052962 calc(100% - ${boxContainerPadding.wide} - 85px))`,
 };
 
 const guardianFoundationBkg = {

--- a/src/pages/our-organisation/index.tsx
+++ b/src/pages/our-organisation/index.tsx
@@ -26,17 +26,18 @@ import {
 } from "../../components/leadershipProfile";
 import { DetailsAndImage } from "../../components/detailsAndImage";
 
-// placeholder values for the our structure and reports background gradients
 const ourStructureBkg = {
-  mobile: `linear-gradient(to top, #052962 20px, ${neutral[97]} 20px)`,
-  tablet: `linear-gradient(to top, #052962 20px, ${neutral[97]} 20px)`,
-  wide: `linear-gradient(to top, #052962 20px, ${neutral[97]} 20px)`,
+  mobile: `linear-gradient(to top, #052962 41px, ${neutral[97]} 41px)`,
+  tablet: `linear-gradient(to top, #052962 100px, ${neutral[97]} 100px)`,
+  desktop: `linear-gradient(to top, #052962 125px, ${neutral[97]} 125px)`,
+  wide: `linear-gradient(to top, #052962 125px, ${neutral[97]} 125px)`,
 };
 
 const reportsBkg = {
-  mobile: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.mobile} - 20px), #052962 calc(100% - ${boxContainerPadding.mobile} - 20px))`,
-  tablet: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 20px), #052962 calc(100% - ${boxContainerPadding.tablet} - 20px))`,
-  wide: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.wide} - 20px), #052962 calc(100% - ${boxContainerPadding.wide} - 20px))`,
+  mobile: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.mobile} - 41px), #052962 calc(100% - ${boxContainerPadding.mobile} - 41px))`,
+  tablet: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 100px), #052962 calc(100% - ${boxContainerPadding.tablet} - 100px))`,
+  desktop: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.tablet} - 125px), #052962 calc(100% - ${boxContainerPadding.tablet} - 125px))`,
+  wide: `linear-gradient(to top, #F6F6F6 calc(100% - ${boxContainerPadding.wide} - 125px), #052962 calc(100% - ${boxContainerPadding.wide} - 125px))`,
 };
 
 const guardianFoundationBkg = {

--- a/src/styles/sharedStyles.tsx
+++ b/src/styles/sharedStyles.tsx
@@ -9,7 +9,6 @@ export const containerCss = (backgroundColor: string) => css`
 
 export const headingCss = css`
   ${titlepiece.small()};
-  max-width: 608px;
   font-size: 32px;
   line-height: 1.15;
   margin: 3px 0 18px 0;


### PR DESCRIPTION
## What does this change?
This updates the "background overlap" values from placeholder values for the elements surrounding the leadership section on the our organisation page for the different breakpoints.

## Images
| Mobile | Desktop |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/44685872/116530060-818e0200-a8d5-11eb-8cde-6b7ac8f52b88.png) | ![image](https://user-images.githubusercontent.com/44685872/116530123-92d70e80-a8d5-11eb-861c-d8a4f0078b19.png) |
