### PR TITLE
Add ophan

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+set -e
 npm install
 npm run build
 mkdir about

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ if (process.env.TEAMCITY_BRANCH === "main") {
 
 const withTM = require("next-transpile-modules")([
   "@guardian/consent-management-platform",
+  "ophan-tracker-js",
 ]); // pass the modules you would like to see transpiled
 
 module.exports = withTM({

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -10,6 +10,7 @@ import { SyntheticEvent } from "react";
 import { ThemeProvider, css, jsx } from "@emotion/react";
 import { cmp } from "@guardian/consent-management-platform";
 import { getGeoLocation } from "./getLocationCookie";
+import 'ophan-tracker-js';
 
 const TODAY = new Date();
 

--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -16,7 +16,6 @@ import ResponsiveCardVariant1 from "../../components/responsiveCardVariant1";
 import FullWidthImage from "../../components/fullWidthImage";
 import dynamic from 'next/dynamic';
 import Head from "next/head";
-import 'ophan-tracker-js';
 
 const Footer = dynamic(() => import("../../components/footer/footer"), {
   ssr: false,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -27,7 +27,6 @@ import { SvgArrowRightStraight } from "@guardian/src-icons";
 import { minWidth } from "../styles/breakpoints";
 import dynamic from "next/dynamic";
 import Head from 'next/head';
-import 'ophan-tracker-js';
 
 const Footer = dynamic(() => import("../components/footer/footer"), {
   ssr: false,

--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -20,7 +20,6 @@ import FullWidthImage from "../../components/fullWidthImage";
 import ResponsiveCardVariant2 from "../../components/responsiveCardVariant2";
 import dynamic from "next/dynamic";
 import Head from "next/head";
-import 'ophan-tracker-js';
 
 const Footer = dynamic(() => import("../../components/footer/footer"), {
   ssr: false,

--- a/src/pages/organisation/index.tsx
+++ b/src/pages/organisation/index.tsx
@@ -26,7 +26,6 @@ import {
 import { DetailsAndImage } from "../../components/detailsAndImage";
 import dynamic from "next/dynamic";
 import Head from "next/head";
-import 'ophan-tracker-js';
 
 const Footer = dynamic(() => import("../../components/footer/footer"), {
   ssr: false,


### PR DESCRIPTION
## What does this change?
- Pre transpile the ophan dependancy.
- add ophan into the footer component which gets loaded asynchronously (only in the browser) and therefore has access to the window object.
- update the ci script to fail in future if it reaches an error instead of passing and going through to riffraff which will fail as it is being provided with an empty artifact.