### PR TITLE
Full width image max height

### DIFF
--- a/src/components/fullWidthImage.tsx
+++ b/src/components/fullWidthImage.tsx
@@ -19,6 +19,7 @@ const FullWidthImage = ({
 }: FullWidthImageProps) => {
   const imageHolderCss = css`
     max-width: 1920px;
+    max-height: 720px;
     margin: 0 auto;
   `;
 


### PR DESCRIPTION
## What does this change?
Give the full width image component a max height of 720px so that it doesn't get too tall on large (wide) screens.

Tested with all the images currently used with this component to ensure the new aspect ratio doesn't crop important parts of the bottom of the image.
