### PR TITLE
[RB] - leadership title css amends

### DIFF
--- a/src/components/leadershipProfile.tsx
+++ b/src/components/leadershipProfile.tsx
@@ -54,7 +54,7 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
     margin-right: ${space[5]}px;
   `;
   const titleCss = css`
-    ${headline.xxxsmall({ fontWeight: "bold" })};
+    ${headline.xxxsmall()};
     color: ${brand[400]};
     border-top: 1px solid ${neutral[86]};
     display: inline-block;
@@ -77,7 +77,7 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
     <figure css={containerCss}>
       <img src={props.imageUrl} css={profileImgCss} />
       <figcaption css={titleCss}>
-        {props.title.name},<br />
+        <strong>{props.title.name},</strong><br />
         {props.title.job},<br />
         {props.title.organisation}
       </figcaption>


### PR DESCRIPTION
## What does this change?
In the leadership section profile components, the name should be bold (font-weight 700) and the job title and organisation should be regular (font-weight 500).

## Images

#### before
![before](https://user-images.githubusercontent.com/2510683/117442581-e200ed00-af2e-11eb-9887-829b67a5187c.png)

#### after
![after](https://user-images.githubusercontent.com/2510683/117442618-ed541880-af2e-11eb-88b8-cbdedbf54d99.png)

