### PR TITLE
Font size, space and lazy loading fixes

### DIFF
--- a/src/components/birthdayThrasher.tsx
+++ b/src/components/birthdayThrasher.tsx
@@ -198,7 +198,7 @@ const BirthdayThrasher = () => (
   <div css={containerCss}>
     <div css={innerContainerCss}>
       <div css={birthdayCopyHolderCss}>
-        <img src="/about/images/thrasher-birthday-copy.svg" />
+        <img src="/about/images/thrasher-birthday-copy.svg" loading="lazy" />
       </div>
       <div css={pAndLinkButtonHolderCss}>
         <p css={pCss}>

--- a/src/components/detailsAndImage.tsx
+++ b/src/components/detailsAndImage.tsx
@@ -54,6 +54,13 @@ export const DetailsAndImage = (props: DetailsAndImageProps) => {
     ${headline.xxxsmall({ fontWeight: "bold" })};
     color: ${brand[400]};
     margin: 0 0 ${space[3]}px;
+    font-size: 16px;
+    ${minWidth.tablet} {
+      font-size: 18px;
+    }
+    ${minWidth.desktop} {
+      font-size: 24px;
+    }
   `;
   const bodyCopyCss = css`
     ${body.medium({ lineHeight: "loose", fontWeight: "regular" })}

--- a/src/components/detailsAndImage.tsx
+++ b/src/components/detailsAndImage.tsx
@@ -73,7 +73,7 @@ export const DetailsAndImage = (props: DetailsAndImageProps) => {
 
   return (
     <figure css={containerCss}>
-      <img src={props.imageUrl} css={profileImgCss} />
+      <img src={props.imageUrl} css={profileImgCss} loading="lazy" />
       <figcaption css={figcationCss}>
         <h2 css={titleCss}>{props.title}</h2>
         <p css={bodyCopyCss}>{props.bodyCopy}</p>

--- a/src/components/detailsAndImage.tsx
+++ b/src/components/detailsAndImage.tsx
@@ -45,6 +45,7 @@ export const DetailsAndImage = (props: DetailsAndImageProps) => {
     ${minWidth.tablet} {
       width: 50%;
       width: calc(50% - 10px);
+      margin: 0;
     }
     ${minWidth.wide} {
       width: calc(50% - 29px);

--- a/src/components/latestNews.tsx
+++ b/src/components/latestNews.tsx
@@ -123,7 +123,7 @@ const LatestNews = () => (
   <div css={containerCss}>
     <div css={innerContainerCss}>
       <div css={imageContainerCss}>
-        <img src="/about/images/front-page-13.jpg" />
+        <img src="/about/images/front-page-13.jpg" loading="lazy" />
       </div>
       <article>
         <h2>Latest News</h2>

--- a/src/components/leadershipProfile.tsx
+++ b/src/components/leadershipProfile.tsx
@@ -90,7 +90,7 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
   return (
     <figure css={containerCss}>
       <div css={imageAndTitleContainer}>
-        <img src={props.imageUrl} css={profileImgCss} />
+        <img src={props.imageUrl} css={profileImgCss} loading="lazy" />
         <figcaption css={titleCss}>
           <strong>{props.title.name},</strong>
           <br />

--- a/src/components/leadershipProfile.tsx
+++ b/src/components/leadershipProfile.tsx
@@ -45,9 +45,11 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
   const containerCss = css`
     margin: 0;
   `;
+  const imageAndTitleContainer = css`
+    display: flex;
+    align-items: center;
+  `;
   const profileImgCss = css`
-    display: inline-block;
-    vertical-align: top;
     width: 94px;
     height: 94px;
     ${minWidth.wide} {
@@ -68,14 +70,12 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
     }
     color: ${brand[400]};
     border-top: 1px solid ${neutral[86]};
-    display: inline-block;
-    vertical-align: top;
     width: calc(100% - 114px);
     ${minWidth.wide} {
       width: calc(100% - 165px);
     }
     padding-top: ${space[1]}px;
-    margin: ${space[5]}px 0 0 auto;
+    margin: 0;
   `;
   const bodyCopyCss = css`
     width: 100%;
@@ -89,12 +89,15 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
   `;
   return (
     <figure css={containerCss}>
-      <img src={props.imageUrl} css={profileImgCss} />
-      <figcaption css={titleCss}>
-        <strong>{props.title.name},</strong><br />
-        {props.title.job},<br />
-        {props.title.organisation}
-      </figcaption>
+      <div css={imageAndTitleContainer}>
+        <img src={props.imageUrl} css={profileImgCss} />
+        <figcaption css={titleCss}>
+          <strong>{props.title.name},</strong>
+          <br />
+          {props.title.job},<br />
+          {props.title.organisation}
+        </figcaption>
+      </div>
       <p css={bodyCopyCss}>{props.bodyCopy}</p>
     </figure>
   );

--- a/src/components/leadershipProfile.tsx
+++ b/src/components/leadershipProfile.tsx
@@ -50,16 +50,30 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
     vertical-align: top;
     width: 94px;
     height: 94px;
+    ${minWidth.wide} {
+      width: 135px;
+      height: 135px;
+    }
     border-radius: 50%;
     margin-right: ${space[5]}px;
   `;
   const titleCss = css`
     ${headline.xxxsmall()};
+    font-size: 16px;
+    ${minWidth.tablet} {
+      font-size: 18px;
+    }
+    ${minWidth.wide} {
+      font-size: 24px;
+    }
     color: ${brand[400]};
     border-top: 1px solid ${neutral[86]};
     display: inline-block;
     vertical-align: top;
     width: calc(100% - 114px);
+    ${minWidth.wide} {
+      width: calc(100% - 165px);
+    }
     padding-top: ${space[1]}px;
     margin: ${space[5]}px 0 0 auto;
   `;

--- a/src/components/responsiveCardVariant1.tsx
+++ b/src/components/responsiveCardVariant1.tsx
@@ -91,7 +91,7 @@ const ResponsiveCardVariant1 = (props: ResponsiveCardVariant1Props) => {
   return (
     <article css={articleCss}>
       <div css={imageHolderCss}>
-        <img src={props.imagePath} css={imageCss} />
+        <img src={props.imagePath} css={imageCss} loading="lazy" />
       </div>
       <div css={titleAndLinkCss}>
         <a href={props.linkUrl} css={titleLinkCss}>

--- a/src/components/responsiveCardVariant2.tsx
+++ b/src/components/responsiveCardVariant2.tsx
@@ -46,7 +46,7 @@ const ResponsiveCardVariant2 = (props: ResponsiveCardVariant2Props) => {
 
   return (
     <a href={props.href} css={containerCss}>
-      <img src={props.imageUrl} css={imageCss} />
+      <img src={props.imageUrl} css={imageCss} loading="lazy" />
       <h2 css={titleCss}>{props.title}</h2>
     </a>
   );

--- a/src/components/unfinishedBusinessThrasher.tsx
+++ b/src/components/unfinishedBusinessThrasher.tsx
@@ -367,14 +367,17 @@ const UnfinishedBusinessThrasher = () => {
           <img
             src="/about/images/unfinished-business-part1.svg"
             css={titlePart1Css}
+            loading="lazy"
           />
           <img
             src="/about/images/unfinished-business-part2.svg"
             css={titlePart2Css}
+            loading="lazy"
           />
           <img
             src="/about/images/unfinished-business-part3.svg"
             css={titlePart3Css}
+            loading="lazy"
           />
           <p css={pCss}>
             From a regional weekly that sold 1,000 copies to a global media

--- a/src/styles/sharedStyles.tsx
+++ b/src/styles/sharedStyles.tsx
@@ -18,7 +18,7 @@ export const headingCss = css`
   }
   ${minWidth.desktop} {
     font-size: 50px;
-    margin: 8px 0 27px 0;
+    margin: 0 0 27px;
   }
 `;
 


### PR DESCRIPTION
## What does this change?
- Fix font size issues in the `DetailsAndImage` and `LeadershipProfile` components
- Increase size of profile pictures in the Leadership section at larger breakpoints
- fix vertical alignment of title copy next to profile picture in the leadership section 
- fix height above section titles so that it is uniform everywhere
- add `loading="lazy"` attribute to img elements for browsers that support it

## Images
Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/123930225-73b53580-d987-11eb-9325-6d850f244f2d.png)  |  ![](https://user-images.githubusercontent.com/2510683/123930184-67c97380-d987-11eb-979e-9896610e1126.png)



Before             |  After
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/2510683/123930465-afe89600-d987-11eb-82f1-4235d236325c.png)  |  ![](https://user-images.githubusercontent.com/2510683/123930498-ba0a9480-d987-11eb-97e1-40adea126438.png)


![Screenshot 2021-06-30 at 09 45 33](https://user-images.githubusercontent.com/2510683/123931168-474de900-d988-11eb-964f-14610a1b2726.png)

