### PR TITLE
The `publicReadAcl` property is now required by Riff Raff

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,4 +8,5 @@ deployments:
     parameters:
       bucket: gu-about-us
       prefixStack: false
+      publicReadAcl: false
       cacheControl: public, max-age=300, stale-while-revalidate=60


### PR DESCRIPTION
## What does this change?
Sets `publicReadAcl` to `false` as this property is [now required](https://github.com/guardian/riff-raff/pull/665) and must be explicitly given.