### PR TITLE
added skip to main content links for a11y on about pages

### DIFF
--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -10,6 +10,7 @@ import { PageStyles } from "../../components/pageStyles";
 import { neutral } from "@guardian/src-foundations/palette";
 import {
   headingCss,
+  skipToContentStyles,
   twoThenOneColumnResponsiveCardHolder,
 } from "../../styles/sharedStyles";
 import ResponsiveCardVariant1 from "../../components/responsiveCardVariant1";
@@ -34,6 +35,9 @@ const OurHistory = () => (
       <title>About our history | The Guardian</title>
     </Head>
     <PageStyles />
+    <a href="#main" css={skipToContentStyles}>
+      Skip to main content
+    </a>
     <Header
       navSections={[
         {
@@ -58,80 +62,82 @@ const OurHistory = () => (
         },
       ]}
     />
-    <FullWidthText theme="dark" title="Our history">
-      <>
-        <p>
-          The Manchester Guardian was founded to promote the liberal interest in
-          the aftermath of the 1819 Peterloo Massacre, and was first published
-          on 5 May 1821. The Guardian achieved national and international
-          recognition under the editorship of CP Scott, who held the post for 57
-          years from 1872.
-        </p>
-        <p>
-          In May 1921, CP Scott wrote a leading article to mark the centenary of
-          the paper setting out the values of the Guardian: honesty, cleanness
-          [integrity], courage, fairness, a sense of duty to the reader and a
-          sense of duty to the community.
-        </p>
-      </>
-    </FullWidthText>
-    <FullWidthImage
-      smallImageUrl="/about/images/history-full-width-small.jpg"
-      largeImageUrl="/about/images/history-full-width-large.jpg"
-    />
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-      overlapTop={true}
-      paddingBottom={true}
-    >
-      <>
-        <h2 css={headingCss}>Read more</h2>
-        <div css={twoThenOneColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="History of the Guardian"
-            imagePath="/about/images/history-2.jpg"
-            linkUrl="https://www.theguardian.com/gnm-archive/2002/jun/06/1"
-          />
-          <ResponsiveCardVariant1
-            title="History of The Observer"
-            imagePath="/about/images/history-3.jpg"
-            linkUrl="https://www.theguardian.com/gnm-archive/2002/jun/06/2"
-          />
-          <ResponsiveCardVariant1
-            title="GNM Archive"
-            imagePath="/about/images/history-4.jpg"
-            linkUrl="https://www.theguardian.com/gnm-archive"
-            alwaysImgOnLeft={true}
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <UnfinishedBusinessThrasher />
-    <BoxContainer theme="light" background={scottTrustBkg}>
-      <>
-        <h2 css={headingCss}>The Scott Trust</h2>
-        <div css={twoThenOneColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Scott Trust values"
-            imagePath="/about/images/front-page-4.jpg"
-            linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/the-scott-trust"
-          />
-          <ResponsiveCardVariant1
-            title="Scott Trust timeline"
-            imagePath="/about/images/history-7.jpg"
-            linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/a-history-of-the-scott-trust"
-          />
-          <ResponsiveCardVariant1
-            title="CP Scott’s centenary essay"
-            imagePath="/about/images/history-8.jpg"
-            linkUrl="https://www.theguardian.com/sustainability/cp-scott-centenary-essay"
-            alwaysImgOnLeft={true}
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <ContactAndWorkForUs />
+    <main id="main" tabIndex={-1}>
+      <FullWidthText theme="dark" title="Our history">
+        <>
+          <p>
+            The Manchester Guardian was founded to promote the liberal interest
+            in the aftermath of the 1819 Peterloo Massacre, and was first
+            published on 5 May 1821. The Guardian achieved national and
+            international recognition under the editorship of CP Scott, who held
+            the post for 57 years from 1872.
+          </p>
+          <p>
+            In May 1921, CP Scott wrote a leading article to mark the centenary
+            of the paper setting out the values of the Guardian: honesty,
+            cleanness [integrity], courage, fairness, a sense of duty to the
+            reader and a sense of duty to the community.
+          </p>
+        </>
+      </FullWidthText>
+      <FullWidthImage
+        smallImageUrl="/about/images/history-full-width-small.jpg"
+        largeImageUrl="/about/images/history-full-width-large.jpg"
+      />
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+        overlapTop={true}
+        paddingBottom={true}
+      >
+        <>
+          <h2 css={headingCss}>Read more</h2>
+          <div css={twoThenOneColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="History of the Guardian"
+              imagePath="/about/images/history-2.jpg"
+              linkUrl="https://www.theguardian.com/gnm-archive/2002/jun/06/1"
+            />
+            <ResponsiveCardVariant1
+              title="History of The Observer"
+              imagePath="/about/images/history-3.jpg"
+              linkUrl="https://www.theguardian.com/gnm-archive/2002/jun/06/2"
+            />
+            <ResponsiveCardVariant1
+              title="GNM Archive"
+              imagePath="/about/images/history-4.jpg"
+              linkUrl="https://www.theguardian.com/gnm-archive"
+              alwaysImgOnLeft={true}
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <UnfinishedBusinessThrasher />
+      <BoxContainer theme="light" background={scottTrustBkg}>
+        <>
+          <h2 css={headingCss}>The Scott Trust</h2>
+          <div css={twoThenOneColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Scott Trust values"
+              imagePath="/about/images/front-page-4.jpg"
+              linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/the-scott-trust"
+            />
+            <ResponsiveCardVariant1
+              title="Scott Trust timeline"
+              imagePath="/about/images/history-7.jpg"
+              linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/a-history-of-the-scott-trust"
+            />
+            <ResponsiveCardVariant1
+              title="CP Scott’s centenary essay"
+              imagePath="/about/images/history-8.jpg"
+              linkUrl="https://www.theguardian.com/sustainability/cp-scott-centenary-essay"
+              alwaysImgOnLeft={true}
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <ContactAndWorkForUs />
+    </main>
     <Footer />
   </>
 );

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -16,6 +16,7 @@ import ResponsiveCardVariant1 from "../components/responsiveCardVariant1";
 import {
   readerFundedSubscribeCardHolderCss,
   readerFundedHeadingCss,
+  skipToContentStyles,
 } from "../styles/sharedStyles";
 import { twoColumnResponsiveCardHolder } from "../styles/sharedStyles";
 import FullWidthImage from "../components/fullWidthImage";
@@ -48,6 +49,9 @@ const HomePage = (): jsx.JSX.Element => (
       <title>About us | The Guardian</title>
     </Head>
     <PageStyles />
+    <a href="#main" css={skipToContentStyles}>
+      Skip to main content
+    </a>
     <Header
       navSections={[
         {
@@ -72,214 +76,216 @@ const HomePage = (): jsx.JSX.Element => (
         },
       ]}
     />
-    <h1
-      // This is a copy of `visuallyHidden` taken from @guardian/source-foundations
-      css={css`
-        position: absolute;
-        opacity: 0;
-        height: 0;
-        width: 0;
-        top: 0;
-        left: 0;
-      `}
-    >
-      About us
-    </h1>
-    <HeaderQuote
-      quote="Since 1821 the mission of the Guardian has been to use clarity and imagination to build hope."
-      author="Katharine Viner, editor-in-chief"
-    />
-    <FullWidthText theme="light">
-      <>
-        <p>
-          Guardian Media Group is a global news organisation that delivers{" "}
-          <span css={highlightedCss}>fearless, investigative journalism</span> -
-          giving a voice to the powerless and holding power to account.
-        </p>
-        <p>
-          Our independent ownership structure means we are entirely free from
-          political and commercial influence.{" "}
-          <span css={highlightedCss}>
-            Only our values determine the stories we choose to cover
-          </span>{" "}
-          – relentlessly and courageously.
-        </p>
-      </>
-    </FullWidthText>
-    <FullWidthImage
-      smallImageUrl="/about/images/front-page-full-width-small.jpg"
-      largeImageUrl="/about/images/front-page-full-width-large.jpg"
-    />
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-      overlapTop={true}
-      paddingBottom={true}
-    >
-      <>
-        <InnerText title="Our Organisation" theme="light">
-          <>
-            <p>
-              The Guardian is owned by Guardian Media Group, which has only one
-              shareholder - the Scott Trust.
-            </p>
-            <p>
-              The Scott Trust, named after our longest serving editor, CP Scott,
-              exists to secure the financial and editorial independence of the
-              Guardian in perpetuity.
-            </p>
-            <p>
-              Today more than half of our revenue comes directly from our
-              readers, helping to support Guardian journalism and keep it open
-              for everyone.
-            </p>
-          </>
-        </InnerText>
-        <div css={twoColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="A mission for journalism: an essay by our editor"
-            imagePath="/about/images/front-page-2.jpg"
-            linkUrl="https://www.theguardian.com/news/2017/nov/16/a-mission-for-journalism-in-a-time-of-crisis"
-          />
-          <ResponsiveCardVariant1
-            title="Guardian Media Group"
-            imagePath="/about/images/front-page-3.jpg"
-            linkUrl="https://www.theguardian.com/gmg"
-          />
-          <ResponsiveCardVariant1
-            title="The Scott Trust and our values"
-            imagePath="/about/images/front-page-4.jpg"
-            linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/the-scott-trust"
-          />
-          <ResponsiveCardVariant1
-            title="CP Scott’s centenary essay"
-            imagePath="/about/images/front-page-5.jpg"
-            linkUrl="https://www.theguardian.com/sustainability/cp-scott-centenary-essay"
-          />
-        </div>
-        <LinkButton
-          priority="primary"
-          size="default"
-          icon={<SvgArrowRightStraight />}
-          iconSide="right"
-          nudgeIcon={true}
-          cssOverrides={LinkButtonCss}
-          href="https://www.theguardian.com/about/organisation"
-        >
-          More on our organisation
-        </LinkButton>
-      </>
-    </BoxContainer>
-    <BirthdayThrasher />
-    <BoxContainer
-      theme="dark"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
-      <>
-        <InnerText title="We're reader funded" theme="dark">
+    <main id="main" tabIndex={-1}>
+      <h1
+        // This is a copy of `visuallyHidden` taken from @guardian/source-foundations
+        css={css`
+          position: absolute;
+          opacity: 0;
+          height: 0;
+          width: 0;
+          top: 0;
+          left: 0;
+        `}
+      >
+        About us
+      </h1>
+      <HeaderQuote
+        quote="Since 1821 the mission of the Guardian has been to use clarity and imagination to build hope."
+        author="Katharine Viner, editor-in-chief"
+      />
+      <FullWidthText theme="light">
+        <>
           <p>
-            The Guardian’s independent, high-impact journalism is powered by its
-            global readership. In 2020 alone, more than 1.5 million readers
-            supported us financially. It’s thanks to this generosity that we can
-            provide quality, trustworthy reporting that’s open for everyone to
-            read. With no shareholders or billionaire owner, we can investigate
-            and challenge without fear or favour, and amplify stories that need
-            to be told. You can show your support for our work today, in
-            whichever way suits you best.
+            Guardian Media Group is a global news organisation that delivers{" "}
+            <span css={highlightedCss}>fearless, investigative journalism</span>{" "}
+            - giving a voice to the powerless and holding power to account.
           </p>
-        </InnerText>
-        <h3 css={readerFundedHeadingCss(true)}>Subscribe</h3>
-        <div css={readerFundedSubscribeCardHolderCss}>
-          <ReaderFundedSubscribeCard
-            imagePath={{
-              mobile: "/about/images/front-page-7-mobile.png",
-              tabletAndAbove: "/about/images/front-page-7-desktop.png",
-            }}
-            title="Digital"
-            bodyText="Enjoy the richest experience of Guardian reporting. Ad-free reading across all your devices, plus premium access to two innovative, award-winning apps."
-            href="https://support.theguardian.com/subscribe/digital"
-          />
-          <ReaderFundedSubscribeCard
-            imagePath={{
-              mobile: "/about/images/front-page-8-mobile.png",
-              tabletAndAbove: "/about/images/front-page-8-desktop.png",
-            }}
-            title="Print"
-            bodyText="Convenient and money-saving, get a newspaper delivered to your door, or pick it up from your local shop. Choose your subscription, from daily to weekend-only."
-            href="https://support.theguardian.com/subscribe/paper"
-          />
-          <ReaderFundedSubscribeCard
-            imagePath={{
-              mobile: "/about/images/front-page-9-mobile.png",
-              tabletAndAbove: "/about/images/front-page-9-desktop.png",
-            }}
-            title="Guardian Weekly"
-            bodyText="Explore the stories that shaped the week with our magazine, delivered worldwide. From top news picks to insightful opinion pieces and engaging long reads."
-            href="https://support.theguardian.com/subscribe/weekly"
-          />
-        </div>
-        <h3 css={readerFundedHeadingCss()}>Make a contribution</h3>
-        <ReaderFundedContributeCard />
-        <ReaderFundedPatronSupport />
-      </>
-    </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-      paddingBottom={true}
-    >
-      <>
-        <InnerText title="Journalism" theme="light">
-          <>
+          <p>
+            Our independent ownership structure means we are entirely free from
+            political and commercial influence.{" "}
+            <span css={highlightedCss}>
+              Only our values determine the stories we choose to cover
+            </span>{" "}
+            – relentlessly and courageously.
+          </p>
+        </>
+      </FullWidthText>
+      <FullWidthImage
+        smallImageUrl="/about/images/front-page-full-width-small.jpg"
+        largeImageUrl="/about/images/front-page-full-width-large.jpg"
+      />
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+        overlapTop={true}
+        paddingBottom={true}
+      >
+        <>
+          <InnerText title="Our Organisation" theme="light">
+            <>
+              <p>
+                The Guardian is owned by Guardian Media Group, which has only
+                one shareholder - the Scott Trust.
+              </p>
+              <p>
+                The Scott Trust, named after our longest serving editor, CP
+                Scott, exists to secure the financial and editorial independence
+                of the Guardian in perpetuity.
+              </p>
+              <p>
+                Today more than half of our revenue comes directly from our
+                readers, helping to support Guardian journalism and keep it open
+                for everyone.
+              </p>
+            </>
+          </InnerText>
+          <div css={twoColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="A mission for journalism: an essay by our editor"
+              imagePath="/about/images/front-page-2.jpg"
+              linkUrl="https://www.theguardian.com/news/2017/nov/16/a-mission-for-journalism-in-a-time-of-crisis"
+            />
+            <ResponsiveCardVariant1
+              title="Guardian Media Group"
+              imagePath="/about/images/front-page-3.jpg"
+              linkUrl="https://www.theguardian.com/gmg"
+            />
+            <ResponsiveCardVariant1
+              title="The Scott Trust and our values"
+              imagePath="/about/images/front-page-4.jpg"
+              linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/the-scott-trust"
+            />
+            <ResponsiveCardVariant1
+              title="CP Scott’s centenary essay"
+              imagePath="/about/images/front-page-5.jpg"
+              linkUrl="https://www.theguardian.com/sustainability/cp-scott-centenary-essay"
+            />
+          </div>
+          <LinkButton
+            priority="primary"
+            size="default"
+            icon={<SvgArrowRightStraight />}
+            iconSide="right"
+            nudgeIcon={true}
+            cssOverrides={LinkButtonCss}
+            href="https://www.theguardian.com/about/organisation"
+          >
+            More on our organisation
+          </LinkButton>
+        </>
+      </BoxContainer>
+      <BirthdayThrasher />
+      <BoxContainer
+        theme="dark"
+        background={{ backgroundColor: `${neutral[97]}` }}
+      >
+        <>
+          <InnerText title="We're reader funded" theme="dark">
             <p>
-              The Guardian is globally renowned for its coverage of politics,
-              the environment, science, social justice, sport and culture. Our
-              journalists deliver agenda-setting investigations, breaking live
-              news, compelling opinion writing and the liveliest features, as
-              well as award-winning podcasts, video documentaries and
-              infographics and visuals.
+              The Guardian’s independent, high-impact journalism is powered by
+              its global readership. In 2020 alone, more than 1.5 million
+              readers supported us financially. It’s thanks to this generosity
+              that we can provide quality, trustworthy reporting that’s open for
+              everyone to read. With no shareholders or billionaire owner, we
+              can investigate and challenge without fear or favour, and amplify
+              stories that need to be told. You can show your support for our
+              work today, in whichever way suits you best.
             </p>
-            <p>
-              Our Covid-19 investigations exposed governmental and social
-              failings, as did the Snowden Files, Panama Papers, Cambridge
-              Analytica Files and the Windrush revelations in the UK.
-            </p>
-            <p>
-              Our teams in the UK, US and Australia produce theguardian.com,
-              Guardian Australia, Guardian US, Guardian Weekly, and the Guardian
-              and Observer newspapers in the UK.
-            </p>
-          </>
-        </InnerText>
-        <div css={twoColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Guardian US"
-            imagePath="/about/images/front-page-11.jpg"
-            linkUrl="https://www.theguardian.com/us"
-            linkText="Visit Guardian US"
-          />
-          <ResponsiveCardVariant1
-            title="Guardian Australia"
-            imagePath="/about/images/front-page-12.jpg"
-            linkUrl="https://www.theguardian.com/au"
-            linkText="Guardian Australia"
-          />
-        </div>
-        <LinkButton
-          priority="primary"
-          size="default"
-          icon={<SvgArrowRightStraight />}
-          iconSide="right"
-          nudgeIcon={true}
-          cssOverrides={LinkButtonCss}
-          href="https://theguardian.com/about/journalism"
-        >
-          More on journalism
-        </LinkButton>
-      </>
-    </BoxContainer>
-    <LatestNews />
-    <ContactAndWorkForUs />
+          </InnerText>
+          <h3 css={readerFundedHeadingCss(true)}>Subscribe</h3>
+          <div css={readerFundedSubscribeCardHolderCss}>
+            <ReaderFundedSubscribeCard
+              imagePath={{
+                mobile: "/about/images/front-page-7-mobile.png",
+                tabletAndAbove: "/about/images/front-page-7-desktop.png",
+              }}
+              title="Digital"
+              bodyText="Enjoy the richest experience of Guardian reporting. Ad-free reading across all your devices, plus premium access to two innovative, award-winning apps."
+              href="https://support.theguardian.com/subscribe/digital"
+            />
+            <ReaderFundedSubscribeCard
+              imagePath={{
+                mobile: "/about/images/front-page-8-mobile.png",
+                tabletAndAbove: "/about/images/front-page-8-desktop.png",
+              }}
+              title="Print"
+              bodyText="Convenient and money-saving, get a newspaper delivered to your door, or pick it up from your local shop. Choose your subscription, from daily to weekend-only."
+              href="https://support.theguardian.com/subscribe/paper"
+            />
+            <ReaderFundedSubscribeCard
+              imagePath={{
+                mobile: "/about/images/front-page-9-mobile.png",
+                tabletAndAbove: "/about/images/front-page-9-desktop.png",
+              }}
+              title="Guardian Weekly"
+              bodyText="Explore the stories that shaped the week with our magazine, delivered worldwide. From top news picks to insightful opinion pieces and engaging long reads."
+              href="https://support.theguardian.com/subscribe/weekly"
+            />
+          </div>
+          <h3 css={readerFundedHeadingCss()}>Make a contribution</h3>
+          <ReaderFundedContributeCard />
+          <ReaderFundedPatronSupport />
+        </>
+      </BoxContainer>
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+        paddingBottom={true}
+      >
+        <>
+          <InnerText title="Journalism" theme="light">
+            <>
+              <p>
+                The Guardian is globally renowned for its coverage of politics,
+                the environment, science, social justice, sport and culture. Our
+                journalists deliver agenda-setting investigations, breaking live
+                news, compelling opinion writing and the liveliest features, as
+                well as award-winning podcasts, video documentaries and
+                infographics and visuals.
+              </p>
+              <p>
+                Our Covid-19 investigations exposed governmental and social
+                failings, as did the Snowden Files, Panama Papers, Cambridge
+                Analytica Files and the Windrush revelations in the UK.
+              </p>
+              <p>
+                Our teams in the UK, US and Australia produce theguardian.com,
+                Guardian Australia, Guardian US, Guardian Weekly, and the
+                Guardian and Observer newspapers in the UK.
+              </p>
+            </>
+          </InnerText>
+          <div css={twoColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Guardian US"
+              imagePath="/about/images/front-page-11.jpg"
+              linkUrl="https://www.theguardian.com/us"
+              linkText="Visit Guardian US"
+            />
+            <ResponsiveCardVariant1
+              title="Guardian Australia"
+              imagePath="/about/images/front-page-12.jpg"
+              linkUrl="https://www.theguardian.com/au"
+              linkText="Guardian Australia"
+            />
+          </div>
+          <LinkButton
+            priority="primary"
+            size="default"
+            icon={<SvgArrowRightStraight />}
+            iconSide="right"
+            nudgeIcon={true}
+            cssOverrides={LinkButtonCss}
+            href="https://theguardian.com/about/journalism"
+          >
+            More on journalism
+          </LinkButton>
+        </>
+      </BoxContainer>
+      <LatestNews />
+      <ContactAndWorkForUs />
+    </main>
     <Footer />
   </>
 );

--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -13,6 +13,7 @@ import {
   headingCss,
   oneThenThreeColumnResponsiveCardHolder,
   responsiveCardV2Holder,
+  skipToContentStyles,
   twoColumnResponsiveCardHolder,
 } from "../../styles/sharedStyles";
 import ResponsiveCardVariant1 from "../../components/responsiveCardVariant1";
@@ -37,6 +38,9 @@ const JournalismPage = () => (
       <title>About our journalism | The Guardian</title>
     </Head>
     <PageStyles />
+    <a href="#main" css={skipToContentStyles}>
+      Skip to main content
+    </a>
     <Header
       navSections={[
         {
@@ -61,224 +65,228 @@ const JournalismPage = () => (
         },
       ]}
     />
-
-    <FullWidthText theme="dark" title="Journalism">
-      <p>
-        The Guardian has a global reputation for holding power to account and
-        championing the voices of those less heard. Our Covid-19 investigations
-        exposed governmental and social failings, as did our earlier work on the
-        Snowden disclosures, the Windrush scandal, Cambridge Analytica and the
-        Panama Papers. We are passionate about the climate emergency, social
-        justice, fairness and progress. We remain dedicated to truth and to
-        bringing about a more hopeful future.
-      </p>
-    </FullWidthText>
-    <FullWidthImage
-      smallImageUrl="/about/images/journalism-full-width-small.jpg"
-      largeImageUrl="/about/images/journalism-full-width-large.jpg"
-    />
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-      overlapTop={true}
-    >
-      <>
-        <InnerText title="Our values and mission for journalism" theme="light">
-          <p>
-            The Scott Trust, which owns the Guardian, was established in 1936 to
-            secure the financial and editorial independence of the Guardian in
-            perpetuity, and to safeguard the journalistic freedom and liberal
-            values of the Guardian free from commercial or political
-            interference. To this day our independence and values drive Guardian
-            journalism.
-          </p>
-        </InnerText>
-        <div css={twoColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="A mission for journalism: an essay by our editor"
-            imagePath="/about/images/front-page-2.jpg"
-            linkUrl="https://www.theguardian.com/news/2017/nov/16/a-mission-for-journalism-in-a-time-of-crisis"
-          />
-          <ResponsiveCardVariant1
-            title="Times change but the Guardian's values don't"
-            imagePath="/about/images/journalism-4.jpg"
-            linkUrl="https://www.theguardian.com/media/2021/may/05/guardian-200-anniversary-covid-pandemic-journalism-editor-mission"
-          />
-          <ResponsiveCardVariant1
-            title="How the Guardian is editorially independent"
-            imagePath="/about/images/journalism-3.jpg"
-            linkUrl="https://www.theguardian.com/about/2017/nov/17/who-owns-the-guardian-our-unique-independent-structure"
-          />
-          <ResponsiveCardVariant1
-            title="CP Scott’s centenary essay"
-            imagePath="/about/images/front-page-5.jpg"
-            linkUrl="https://www.theguardian.com/sustainability/cp-scott-centenary-essay"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
-      <>
-        <h2 css={headingCss}>Editors</h2>
-        <div css={oneThenThreeColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Katharine Viner, editor-in-chief, GNM"
-            imagePath="/about/images/journalism-5.jpg"
-            linkUrl="https://www.theguardian.com/profile/katharineviner"
-            alwaysImgOnLeft={true}
-          />
-          <ResponsiveCardVariant1
-            title="John Mulholland, editor of Guardian US"
-            imagePath="/about/images/journalism-6.jpg"
-            linkUrl="https://www.theguardian.com/profile/johnmulholland"
-          />
-          <ResponsiveCardVariant1
-            title="Lenore Taylor, editor of Guardian Australia"
-            imagePath="/about/images/journalism-7.jpg"
-            linkUrl="https://www.theguardian.com/profile/lenore-taylor"
-          />
-          <ResponsiveCardVariant1
-            title="Paul Webster, editor of The Observer"
-            imagePath="/about/images/journalism-8.jpg"
-            linkUrl="https://www.theguardian.com/profile/paul-webster"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
-      <>
-        <InnerText title="Guardian journalism" theme="light">
-          <p>
-            The Guardian’s purposeful journalism, serving our global audience,
-            includes print and digital products, podcasts, video, infographics,
-            email newsletters and a dedicated programme of live discussions,
-            debates and interviews.
-          </p>
-        </InnerText>
-        <div css={responsiveCardV2Holder}>
-          <ResponsiveCardVariant2
-            title="Website"
-            href="https://www.theguardian.com"
-            imageUrl="/about/images/journalism-9.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="Apps"
-            href="https://support.theguardian.com/subscribe/digital"
-            imageUrl="/about/images/journalism-10.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="Newsletters"
-            href="https://www.theguardian.com/email-newsletters"
-            imageUrl="/about/images/journalism-11.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="The Guardian newspaper"
-            href="https://www.theguardian.com/gnm-archive/2002/jun/06/1"
-            imageUrl="/about/images/journalism-12.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="The Observer newspaper"
-            href="https://www.theguardian.com/gnm-archive/2002/jun/06/2"
-            imageUrl="/about/images/journalism-13.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="The Guardian Weekly"
-            href="https://www.theguardian.com/weekly"
-            imageUrl="/about/images/journalism-14.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="Podcasts"
-            href="https://www.theguardian.com/podcasts"
-            imageUrl="/about/images/journalism-15.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="Video & documentaries"
-            href="https://www.theguardian.com/video"
-            imageUrl="/about/images/journalism-16.jpg"
-          />
-          <ResponsiveCardVariant2
-            title="Live events"
-            href="https://membership.theguardian.com/events"
-            imageUrl="/about/images/journalism-17.jpg"
-          />
-        </div>
-        <div css={twoColumnResponsiveCardHolder}>
-          <h3>International editions</h3>
-          <ResponsiveCardVariant1
-            title="Guardian US"
-            imagePath="/about/images/front-page-11.jpg"
-            linkUrl="https://www.theguardian.com/us"
-            linkText="Visit Guardian US"
-          />
-          <ResponsiveCardVariant1
-            title="Guardian Australia"
-            imagePath="/about/images/front-page-12.jpg"
-            linkUrl="https://www.theguardian.com/au"
-            linkText="Guardian Australia"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
-      <>
-        <h2 css={headingCss}>Editorial standards</h2>
-        <div css={twoColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Editorial guidelines for journalists"
-            imagePath="/about/images/journalism-20.jpg"
-            linkUrl="https://www.theguardian.com/info/2015/aug/05/the-guardians-editorial-code"
-          />
-          <ResponsiveCardVariant1
-            title="About our readers’ editor"
-            imagePath="/about/images/journalism-21.jpg"
-            linkUrl="https://www.theguardian.com/info/2013/sep/23/guardian-readers-editor"
-          />
-          <ResponsiveCardVariant1
-            title="Community standards"
-            imagePath="/about/images/journalism-22.jpg"
-            linkUrl="https://www.theguardian.com/community-standards"
-          />
-          <ResponsiveCardVariant1
-            title="Style guide"
-            imagePath="/about/images/journalism-23.jpg"
-            linkUrl="https://www.theguardian.com/guardian-observer-style-guide-a"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer theme="light" background={gotAStoryBkg}>
-      <>
-        <InnerText title="Got a story?" theme="light">
-          <p>
-            The Guardian welcomes anonymous and confidential news tips to help
-            inform our journalism. Find out how to get in touch with the
-            Guardian to share a story or reach our editorial departments.
-          </p>
-        </InnerText>
-        <div css={twoColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Contact us securely"
-            imagePath="/about/images/journalism-24.jpg"
-            linkUrl="https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely"
-          />
-          <ResponsiveCardVariant1
-            title="Contact our editorial desks "
-            imagePath="/about/images/journalism-25.jpg"
-            linkUrl="https://www.theguardian.com/help/contact-us"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <ContactAndWorkForUs />
+    <main id="main" tabIndex={-1}>
+      <FullWidthText theme="dark" title="Journalism">
+        <p>
+          The Guardian has a global reputation for holding power to account and
+          championing the voices of those less heard. Our Covid-19
+          investigations exposed governmental and social failings, as did our
+          earlier work on the Snowden disclosures, the Windrush scandal,
+          Cambridge Analytica and the Panama Papers. We are passionate about the
+          climate emergency, social justice, fairness and progress. We remain
+          dedicated to truth and to bringing about a more hopeful future.
+        </p>
+      </FullWidthText>
+      <FullWidthImage
+        smallImageUrl="/about/images/journalism-full-width-small.jpg"
+        largeImageUrl="/about/images/journalism-full-width-large.jpg"
+      />
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+        overlapTop={true}
+      >
+        <>
+          <InnerText
+            title="Our values and mission for journalism"
+            theme="light"
+          >
+            <p>
+              The Scott Trust, which owns the Guardian, was established in 1936
+              to secure the financial and editorial independence of the Guardian
+              in perpetuity, and to safeguard the journalistic freedom and
+              liberal values of the Guardian free from commercial or political
+              interference. To this day our independence and values drive
+              Guardian journalism.
+            </p>
+          </InnerText>
+          <div css={twoColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="A mission for journalism: an essay by our editor"
+              imagePath="/about/images/front-page-2.jpg"
+              linkUrl="https://www.theguardian.com/news/2017/nov/16/a-mission-for-journalism-in-a-time-of-crisis"
+            />
+            <ResponsiveCardVariant1
+              title="Times change but the Guardian's values don't"
+              imagePath="/about/images/journalism-4.jpg"
+              linkUrl="https://www.theguardian.com/media/2021/may/05/guardian-200-anniversary-covid-pandemic-journalism-editor-mission"
+            />
+            <ResponsiveCardVariant1
+              title="How the Guardian is editorially independent"
+              imagePath="/about/images/journalism-3.jpg"
+              linkUrl="https://www.theguardian.com/about/2017/nov/17/who-owns-the-guardian-our-unique-independent-structure"
+            />
+            <ResponsiveCardVariant1
+              title="CP Scott’s centenary essay"
+              imagePath="/about/images/front-page-5.jpg"
+              linkUrl="https://www.theguardian.com/sustainability/cp-scott-centenary-essay"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+      >
+        <>
+          <h2 css={headingCss}>Editors</h2>
+          <div css={oneThenThreeColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Katharine Viner, editor-in-chief, GNM"
+              imagePath="/about/images/journalism-5.jpg"
+              linkUrl="https://www.theguardian.com/profile/katharineviner"
+              alwaysImgOnLeft={true}
+            />
+            <ResponsiveCardVariant1
+              title="John Mulholland, editor of Guardian US"
+              imagePath="/about/images/journalism-6.jpg"
+              linkUrl="https://www.theguardian.com/profile/johnmulholland"
+            />
+            <ResponsiveCardVariant1
+              title="Lenore Taylor, editor of Guardian Australia"
+              imagePath="/about/images/journalism-7.jpg"
+              linkUrl="https://www.theguardian.com/profile/lenore-taylor"
+            />
+            <ResponsiveCardVariant1
+              title="Paul Webster, editor of The Observer"
+              imagePath="/about/images/journalism-8.jpg"
+              linkUrl="https://www.theguardian.com/profile/paul-webster"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+      >
+        <>
+          <InnerText title="Guardian journalism" theme="light">
+            <p>
+              The Guardian’s purposeful journalism, serving our global audience,
+              includes print and digital products, podcasts, video,
+              infographics, email newsletters and a dedicated programme of live
+              discussions, debates and interviews.
+            </p>
+          </InnerText>
+          <div css={responsiveCardV2Holder}>
+            <ResponsiveCardVariant2
+              title="Website"
+              href="https://www.theguardian.com"
+              imageUrl="/about/images/journalism-9.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="Apps"
+              href="https://support.theguardian.com/subscribe/digital"
+              imageUrl="/about/images/journalism-10.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="Newsletters"
+              href="https://www.theguardian.com/email-newsletters"
+              imageUrl="/about/images/journalism-11.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="The Guardian newspaper"
+              href="https://www.theguardian.com/gnm-archive/2002/jun/06/1"
+              imageUrl="/about/images/journalism-12.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="The Observer newspaper"
+              href="https://www.theguardian.com/gnm-archive/2002/jun/06/2"
+              imageUrl="/about/images/journalism-13.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="The Guardian Weekly"
+              href="https://www.theguardian.com/weekly"
+              imageUrl="/about/images/journalism-14.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="Podcasts"
+              href="https://www.theguardian.com/podcasts"
+              imageUrl="/about/images/journalism-15.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="Video & documentaries"
+              href="https://www.theguardian.com/video"
+              imageUrl="/about/images/journalism-16.jpg"
+            />
+            <ResponsiveCardVariant2
+              title="Live events"
+              href="https://membership.theguardian.com/events"
+              imageUrl="/about/images/journalism-17.jpg"
+            />
+          </div>
+          <div css={twoColumnResponsiveCardHolder}>
+            <h3>International editions</h3>
+            <ResponsiveCardVariant1
+              title="Guardian US"
+              imagePath="/about/images/front-page-11.jpg"
+              linkUrl="https://www.theguardian.com/us"
+              linkText="Visit Guardian US"
+            />
+            <ResponsiveCardVariant1
+              title="Guardian Australia"
+              imagePath="/about/images/front-page-12.jpg"
+              linkUrl="https://www.theguardian.com/au"
+              linkText="Guardian Australia"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+      >
+        <>
+          <h2 css={headingCss}>Editorial standards</h2>
+          <div css={twoColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Editorial guidelines for journalists"
+              imagePath="/about/images/journalism-20.jpg"
+              linkUrl="https://www.theguardian.com/info/2015/aug/05/the-guardians-editorial-code"
+            />
+            <ResponsiveCardVariant1
+              title="About our readers’ editor"
+              imagePath="/about/images/journalism-21.jpg"
+              linkUrl="https://www.theguardian.com/info/2013/sep/23/guardian-readers-editor"
+            />
+            <ResponsiveCardVariant1
+              title="Community standards"
+              imagePath="/about/images/journalism-22.jpg"
+              linkUrl="https://www.theguardian.com/community-standards"
+            />
+            <ResponsiveCardVariant1
+              title="Style guide"
+              imagePath="/about/images/journalism-23.jpg"
+              linkUrl="https://www.theguardian.com/guardian-observer-style-guide-a"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer theme="light" background={gotAStoryBkg}>
+        <>
+          <InnerText title="Got a story?" theme="light">
+            <p>
+              The Guardian welcomes anonymous and confidential news tips to help
+              inform our journalism. Find out how to get in touch with the
+              Guardian to share a story or reach our editorial departments.
+            </p>
+          </InnerText>
+          <div css={twoColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Contact us securely"
+              imagePath="/about/images/journalism-24.jpg"
+              linkUrl="https://www.theguardian.com/help/ng-interactive/2017/mar/17/contact-the-guardian-securely"
+            />
+            <ResponsiveCardVariant1
+              title="Contact our editorial desks "
+              imagePath="/about/images/journalism-25.jpg"
+              linkUrl="https://www.theguardian.com/help/contact-us"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <ContactAndWorkForUs />
+    </main>
     <Footer />
   </>
 );

--- a/src/pages/organisation/index.tsx
+++ b/src/pages/organisation/index.tsx
@@ -15,6 +15,7 @@ import ResponsiveCardVariant1 from "../../components/responsiveCardVariant1";
 import {
   headingCss,
   singleColumnResponsiveCardHolder,
+  skipToContentStyles,
   threeColumnResponsiveCardHolder,
   twoColumnResponsiveCardHolder,
 } from "../../styles/sharedStyles";
@@ -57,6 +58,9 @@ const HomePage = () => (
       <title>About our organisation | The Guardian</title>
     </Head>
     <PageStyles />
+    <a href="#main" css={skipToContentStyles}>
+      Skip to main content
+    </a>
     <Header
       navSections={[
         {
@@ -81,246 +85,254 @@ const HomePage = () => (
         },
       ]}
     />
-    <FullWidthText theme="dark" title="Our organisation">
-      <>
-        <p>
-          Guardian Media Group has only one shareholder - The Scott Trust. The
-          Trust forms part of a unique ownership structure for the Guardian that
-          ensures editorial interests remain free of commercial pressures.
-        </p>
-        <p>
-          Today more than half of our revenue comes directly from our readers,
-          helping to support Guardian journalism and keep it open for everyone.
-        </p>
-      </>
-    </FullWidthText>
-    <FullWidthImage
-      smallImageUrl="/about/images/organisation-full-width-small.jpg"
-      largeImageUrl="/about/images/organisation-full-width-large.jpg"
-    />
-    <BoxContainer theme="light" background={ourStructureBkg} overlapTop={true}>
-      <>
-        <InnerText title="Our structure" theme="light">
-          <>
-            <p>
-              Guardian Media Group (GMG) owns Guardian News &amp; Media (GNM) -
-              the publisher of the Guardian and Observer newspapers in the UK,
-              theguardian.com and Guardian US and Australia.
-            </p>
-            <p>
-              The Scott Trust, named after our longest serving editor, CP Scott,
-              exists to secure the financial and editorial independence of the
-              Guardian in perpetuity.
-            </p>
-          </>
-        </InnerText>
-        <div css={twoColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="About the Scott Trust"
-            imagePath="/about/images/organisation-2.jpg"
-            linkUrl="https://www.theguardian.com/the-scott-trust"
-          />
-          <ResponsiveCardVariant1
-            title="The Scott Trust board"
-            imagePath="/about/images/organisation-3.jpg"
-            linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/the-scott-trust-board"
-          />
-          <ResponsiveCardVariant1
-            title="About Guardian Media Group"
-            imagePath="/about/images/front-page-3.jpg"
-            linkUrl="https://www.theguardian.com/gmg"
-          />
-          <ResponsiveCardVariant1
-            title="GMG Board"
-            imagePath="/about/images/organisation-5.jpg"
-            linkUrl="https://www.theguardian.com/gmg/2015/jul/23/gnm-board"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer theme="light" background={{ backgroundColor: brand[400] }}>
-      <>
-        <h2 css={headingCss}>Leadership</h2>
-        <div css={leadershipProfilesHolder}>
-          <LeadershipProfile
-            imageUrl="/about/images/organisation-6.jpg"
-            title={{
-              name: "Katharine Viner",
-              job: "editor-in-chief",
-              organisation: "Guardian News & Media",
-            }}
-            bodyCopy="Katharine Viner is the editor-in-chief of Guardian News & Media. The editor-in-chief reports only to the Scott Trust and has complete editorial independence. She also sits on the boards of the Scott Trust and Guardian Media Group, and the executive committee of Guardian News & Media."
-          />
-          <LeadershipProfile
-            imageUrl="/about/images/organisation-7.jpg"
-            title={{
-              name: "Keith Underwood",
-              job: "chief executive",
-              organisation: "Guardian Media Group",
-            }}
-            bodyCopy="Keith Underwood is the interim chief executive of Guardian Media Group, alongside his position as chief financial and operating officer. As chief executive he also sits on the boards of the Scott Trust, Guardian Media Group and the executive committee of Guardian News & Media."
-          />
-        </div>
-        <DetailsAndImage
-          imageUrl="/about/images/organisation-8.jpg"
-          title="GNM executive committee"
-          bodyCopy="Read more about the management team of Guardian News & Media"
-          readMoreUrl="https://www.theguardian.com/gnm-press-office/gnm-executive-committee"
-        />
-      </>
-    </BoxContainer>
-    <BoxContainer theme="light" background={reportsBkg}>
-      <>
-        <h2 css={headingCss}>GMG financial reports and corporate policies</h2>
-        <div css={twoColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Financial reports"
-            imagePath="/about/images/organisation-9.jpg"
-            linkUrl="https://www.theguardian.com/gmg/2015/jul/27/guardian-media-group-annual-financial-reports"
-          />
-          <ResponsiveCardVariant1
-            title="Corporate policies"
-            imagePath="/about/images/organisation-10.jpg"
-            linkUrl="https://www.theguardian.com/gmg/2018/mar/14/corporate-reports-and-policies"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer theme="light" background={{ backgroundColor: neutral[97] }}>
-      <>
-        <InnerText title="Sustainability" theme="light">
-          <>
-            <p>
-              As an organisation we recognise that the escalating climate crisis
-              is the defining issue of our times.
-            </p>
-            <p>
-              In 2019, we became the first major news organisation to certify as
-              a B Corporation, and made a climate pledge to our readers
-              committing to reach net zero carbon emissions by 2030.
-            </p>
-            <p>
-              In 2020 we announced we will no longer accept advertising from oil
-              and gas companies, becoming the first major global news
-              organisation to stop accepting money from companies that extract
-              fossil fuels.
-            </p>
-          </>
-        </InnerText>
-        <div css={threeColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="GMG as a B Corporation"
-            imagePath="/about/images/organisation-11.jpg"
-            linkUrl="https://www.theguardian.com/gnm-press-office/2019/oct/16/guardian-media-group-becomes-first-major-news-organisation-to-become-a-b-corporation-and-pledges-to-reach-net-zero-emissions-by-2030"
-          />
-          <ResponsiveCardVariant1
-            title="Positive impact and sustainability report"
-            imagePath="/about/images/organisation-13.jpg"
-            linkUrl="https://www.theguardian.com/gmg/2021/aug/25/positive-impact-and-sustainability-report"
-          />
-          <ResponsiveCardVariant1
-            title="Our climate pledge"
-            imagePath="/about/images/organisation-12.jpg"
-            linkUrl="https://www.theguardian.com/environment/2021/oct/25/the-guardians-climate-pledge"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
-      <>
-        <InnerText title="Our people" theme="light">
+    <main id="main" tabIndex={-1}>
+      <FullWidthText theme="dark" title="Our organisation">
+        <>
           <p>
-            We value and respect all differences in people, seen and unseen, and
-            aspire to an open, supportive and inclusive culture which makes the
-            Guardian a good place to work for everyone. We have a global
-            workforce, with the majority of our staff in the UK and growing
-            operations in Australia and the US.
+            Guardian Media Group has only one shareholder - The Scott Trust. The
+            Trust forms part of a unique ownership structure for the Guardian
+            that ensures editorial interests remain free of commercial
+            pressures.
           </p>
-        </InnerText>
-        <div css={threeColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Diversity, equity and inclusion"
-            imagePath="/about/images/organisation-14.jpg"
-            linkUrl="https://www.theguardian.com/about/2021/apr/30/diversity-equity-and-inclusion"
-          />
-          <ResponsiveCardVariant1
-            title="Employee engagement"
-            imagePath="/about/images/organisation-workplace.jpg"
-            linkUrl="https://www.theguardian.com/about/2021/apr/30/employee-engagement"
-          />
-          <ResponsiveCardVariant1
-            title="Work for us"
-            imagePath="/about/images/organisation-16.jpg"
-            linkUrl="https://workforus.theguardian.com/"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer
-      theme="light"
-      background={{ backgroundColor: `${neutral[97]}` }}
-    >
-      <>
-        <InnerText title="Our revenue mix" theme="light">
           <p>
-            GMG operates a diverse revenue model including reader revenues,
-            advertising, jobs advertising, licensing and philanthropic funding.
-            We are increasingly global with growing commercial operations in the
-            US and Australia. Revenue from readers now accounts for over 50% of
-            GMG's annual revenue, with more than half of reader revenue coming
-            from readers outside the UK.
+            Today more than half of our revenue comes directly from our readers,
+            helping to support Guardian journalism and keep it open for
+            everyone.
           </p>
-        </InnerText>
-        <DetailsAndImage
-          imageUrl="/about/images/organisation-17.jpg"
-          title="Reader funding"
-          bodyCopy="Readers can support the Guardian through a digital or print subscription, a recurring or single contribution or as a patron. Read more about our subscriptions:"
-          readMoreUrl="https://support.theguardian.com/uk/subscribe?CMP=ppc_mem_&gclid=CjwKCAjw6fCCBhBNEiwAem5SOy61gdjmDXnbjnURNn2-xbO9vEeSd2xYypEw7Y4u9A-qu5-ZJ-ZehxoC41oQAvD_BwE"
-        />
-        <div css={threeColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Advertising"
-            imagePath="/about/images/organisation-18.jpg"
-            linkUrl="https://advertising.theguardian.com/"
+        </>
+      </FullWidthText>
+      <FullWidthImage
+        smallImageUrl="/about/images/organisation-full-width-small.jpg"
+        largeImageUrl="/about/images/organisation-full-width-large.jpg"
+      />
+      <BoxContainer
+        theme="light"
+        background={ourStructureBkg}
+        overlapTop={true}
+      >
+        <>
+          <InnerText title="Our structure" theme="light">
+            <>
+              <p>
+                Guardian Media Group (GMG) owns Guardian News &amp; Media (GNM)
+                - the publisher of the Guardian and Observer newspapers in the
+                UK, theguardian.com and Guardian US and Australia.
+              </p>
+              <p>
+                The Scott Trust, named after our longest serving editor, CP
+                Scott, exists to secure the financial and editorial independence
+                of the Guardian in perpetuity.
+              </p>
+            </>
+          </InnerText>
+          <div css={twoColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="About the Scott Trust"
+              imagePath="/about/images/organisation-2.jpg"
+              linkUrl="https://www.theguardian.com/the-scott-trust"
+            />
+            <ResponsiveCardVariant1
+              title="The Scott Trust board"
+              imagePath="/about/images/organisation-3.jpg"
+              linkUrl="https://www.theguardian.com/the-scott-trust/2015/jul/26/the-scott-trust-board"
+            />
+            <ResponsiveCardVariant1
+              title="About Guardian Media Group"
+              imagePath="/about/images/front-page-3.jpg"
+              linkUrl="https://www.theguardian.com/gmg"
+            />
+            <ResponsiveCardVariant1
+              title="GMG Board"
+              imagePath="/about/images/organisation-5.jpg"
+              linkUrl="https://www.theguardian.com/gmg/2015/jul/23/gnm-board"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer theme="light" background={{ backgroundColor: brand[400] }}>
+        <>
+          <h2 css={headingCss}>Leadership</h2>
+          <div css={leadershipProfilesHolder}>
+            <LeadershipProfile
+              imageUrl="/about/images/organisation-6.jpg"
+              title={{
+                name: "Katharine Viner",
+                job: "editor-in-chief",
+                organisation: "Guardian News & Media",
+              }}
+              bodyCopy="Katharine Viner is the editor-in-chief of Guardian News & Media. The editor-in-chief reports only to the Scott Trust and has complete editorial independence. She also sits on the boards of the Scott Trust and Guardian Media Group, and the executive committee of Guardian News & Media."
+            />
+            <LeadershipProfile
+              imageUrl="/about/images/organisation-7.jpg"
+              title={{
+                name: "Keith Underwood",
+                job: "chief executive",
+                organisation: "Guardian Media Group",
+              }}
+              bodyCopy="Keith Underwood is the interim chief executive of Guardian Media Group, alongside his position as chief financial and operating officer. As chief executive he also sits on the boards of the Scott Trust, Guardian Media Group and the executive committee of Guardian News & Media."
+            />
+          </div>
+          <DetailsAndImage
+            imageUrl="/about/images/organisation-8.jpg"
+            title="GNM executive committee"
+            bodyCopy="Read more about the management team of Guardian News & Media"
+            readMoreUrl="https://www.theguardian.com/gnm-press-office/gnm-executive-committee"
           />
-          <ResponsiveCardVariant1
-            title="Guardian Jobs"
-            imagePath="/about/images/organisation-19.jpg"
-            linkUrl="https://jobs.theguardian.com/"
+        </>
+      </BoxContainer>
+      <BoxContainer theme="light" background={reportsBkg}>
+        <>
+          <h2 css={headingCss}>GMG financial reports and corporate policies</h2>
+          <div css={twoColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Financial reports"
+              imagePath="/about/images/organisation-9.jpg"
+              linkUrl="https://www.theguardian.com/gmg/2015/jul/27/guardian-media-group-annual-financial-reports"
+            />
+            <ResponsiveCardVariant1
+              title="Corporate policies"
+              imagePath="/about/images/organisation-10.jpg"
+              linkUrl="https://www.theguardian.com/gmg/2018/mar/14/corporate-reports-and-policies"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer theme="light" background={{ backgroundColor: neutral[97] }}>
+        <>
+          <InnerText title="Sustainability" theme="light">
+            <>
+              <p>
+                As an organisation we recognise that the escalating climate
+                crisis is the defining issue of our times.
+              </p>
+              <p>
+                In 2019, we became the first major news organisation to certify
+                as a B Corporation, and made a climate pledge to our readers
+                committing to reach net zero carbon emissions by 2030.
+              </p>
+              <p>
+                In 2020 we announced we will no longer accept advertising from
+                oil and gas companies, becoming the first major global news
+                organisation to stop accepting money from companies that extract
+                fossil fuels.
+              </p>
+            </>
+          </InnerText>
+          <div css={threeColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="GMG as a B Corporation"
+              imagePath="/about/images/organisation-11.jpg"
+              linkUrl="https://www.theguardian.com/gnm-press-office/2019/oct/16/guardian-media-group-becomes-first-major-news-organisation-to-become-a-b-corporation-and-pledges-to-reach-net-zero-emissions-by-2030"
+            />
+            <ResponsiveCardVariant1
+              title="Positive impact and sustainability report"
+              imagePath="/about/images/organisation-13.jpg"
+              linkUrl="https://www.theguardian.com/gmg/2021/aug/25/positive-impact-and-sustainability-report"
+            />
+            <ResponsiveCardVariant1
+              title="Our climate pledge"
+              imagePath="/about/images/organisation-12.jpg"
+              linkUrl="https://www.theguardian.com/environment/2021/oct/25/the-guardians-climate-pledge"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+      >
+        <>
+          <InnerText title="Our people" theme="light">
+            <p>
+              We value and respect all differences in people, seen and unseen,
+              and aspire to an open, supportive and inclusive culture which
+              makes the Guardian a good place to work for everyone. We have a
+              global workforce, with the majority of our staff in the UK and
+              growing operations in Australia and the US.
+            </p>
+          </InnerText>
+          <div css={threeColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Diversity, equity and inclusion"
+              imagePath="/about/images/organisation-14.jpg"
+              linkUrl="https://www.theguardian.com/about/2021/apr/30/diversity-equity-and-inclusion"
+            />
+            <ResponsiveCardVariant1
+              title="Employee engagement"
+              imagePath="/about/images/organisation-workplace.jpg"
+              linkUrl="https://www.theguardian.com/about/2021/apr/30/employee-engagement"
+            />
+            <ResponsiveCardVariant1
+              title="Work for us"
+              imagePath="/about/images/organisation-16.jpg"
+              linkUrl="https://workforus.theguardian.com/"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer
+        theme="light"
+        background={{ backgroundColor: `${neutral[97]}` }}
+      >
+        <>
+          <InnerText title="Our revenue mix" theme="light">
+            <p>
+              GMG operates a diverse revenue model including reader revenues,
+              advertising, jobs advertising, licensing and philanthropic
+              funding. We are increasingly global with growing commercial
+              operations in the US and Australia. Revenue from readers now
+              accounts for over 50% of GMG's annual revenue, with more than half
+              of reader revenue coming from readers outside the UK.
+            </p>
+          </InnerText>
+          <DetailsAndImage
+            imageUrl="/about/images/organisation-17.jpg"
+            title="Reader funding"
+            bodyCopy="Readers can support the Guardian through a digital or print subscription, a recurring or single contribution or as a patron. Read more about our subscriptions:"
+            readMoreUrl="https://support.theguardian.com/uk/subscribe?CMP=ppc_mem_&gclid=CjwKCAjw6fCCBhBNEiwAem5SOy61gdjmDXnbjnURNn2-xbO9vEeSd2xYypEw7Y4u9A-qu5-ZJ-ZehxoC41oQAvD_BwE"
           />
-          <ResponsiveCardVariant1
-            title="Philanthropic funding"
-            imagePath="/about/images/organisation-20.jpg"
-            linkUrl="https://www.theguardian.com/info/2018/oct/02/philanthropic-partnerships-at-the-guardian"
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <BoxContainer theme="light" background={guardianFoundationBkg}>
-      <>
-        <InnerText title="Guardian Foundation" theme="light">
-          <p>
-            Through the Scott Trust, our independent charity the Guardian
-            Foundation supports media under threat, promotes diversity in the
-            media and empowers children and young people to engage with the
-            news. The charity envisions a world in which all people can tell
-            their stories, access the truth and hold power to account.
-          </p>
-        </InnerText>
-        <div css={singleColumnResponsiveCardHolder}>
-          <ResponsiveCardVariant1
-            title="Guardian Foundation"
-            imagePath="/about/images/organisation-21.jpg"
-            linkUrl="https://theguardianfoundation.org/"
-            alwaysImgOnLeft={true}
-          />
-        </div>
-      </>
-    </BoxContainer>
-    <ContactAndWorkForUs />
+          <div css={threeColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Advertising"
+              imagePath="/about/images/organisation-18.jpg"
+              linkUrl="https://advertising.theguardian.com/"
+            />
+            <ResponsiveCardVariant1
+              title="Guardian Jobs"
+              imagePath="/about/images/organisation-19.jpg"
+              linkUrl="https://jobs.theguardian.com/"
+            />
+            <ResponsiveCardVariant1
+              title="Philanthropic funding"
+              imagePath="/about/images/organisation-20.jpg"
+              linkUrl="https://www.theguardian.com/info/2018/oct/02/philanthropic-partnerships-at-the-guardian"
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <BoxContainer theme="light" background={guardianFoundationBkg}>
+        <>
+          <InnerText title="Guardian Foundation" theme="light">
+            <p>
+              Through the Scott Trust, our independent charity the Guardian
+              Foundation supports media under threat, promotes diversity in the
+              media and empowers children and young people to engage with the
+              news. The charity envisions a world in which all people can tell
+              their stories, access the truth and hold power to account.
+            </p>
+          </InnerText>
+          <div css={singleColumnResponsiveCardHolder}>
+            <ResponsiveCardVariant1
+              title="Guardian Foundation"
+              imagePath="/about/images/organisation-21.jpg"
+              linkUrl="https://theguardianfoundation.org/"
+              alwaysImgOnLeft={true}
+            />
+          </div>
+        </>
+      </BoxContainer>
+      <ContactAndWorkForUs />
+    </main>
     <Footer />
   </>
 );

--- a/src/styles/sharedStyles.tsx
+++ b/src/styles/sharedStyles.tsx
@@ -1,6 +1,10 @@
 import { css } from "@emotion/react";
 import { neutral, space } from "@guardian/src-foundations";
-import { headline, titlepiece } from "@guardian/src-foundations/typography";
+import {
+  headline,
+  textSans,
+  titlepiece,
+} from "@guardian/src-foundations/typography";
 import { minWidth } from "./breakpoints";
 
 export const containerCss = (backgroundColor: string) => css`
@@ -19,6 +23,29 @@ export const headingCss = css`
   ${minWidth.desktop} {
     font-size: 50px;
     margin: 0 0 27px;
+  }
+`;
+
+export const skipToContentStyles = css`
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+  ${textSans.medium()}
+  &:active,
+  &:focus {
+    clip: auto;
+    height: auto;
+    margin: 0;
+    overflow: visible;
+    position: static;
+    white-space: normal;
+    width: auto;
   }
 `;
 


### PR DESCRIPTION
Co-Authored-By: Max Duval <hi@mxdvl.com>

## What does this change?
Added skip to main content links on about pages
This fixes https://github.com/guardian/dotcom-rendering/issues/5037

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
This is testable by navigating with the tab button on keyboard.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->


## Images
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/110032454/184926641-9a3a37d3-004f-45e1-ad85-ee7b54e2773f.png">

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [X] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [X] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
