### PR TITLE
Remove unnecessary tabindex

### DIFF
--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -62,7 +62,7 @@ const OurHistory = () => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main">
       <FullWidthText theme="dark" title="Our history">
         <>
           <p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -76,7 +76,7 @@ const HomePage = (): jsx.JSX.Element => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main" >
       <h1
         // This is a copy of `visuallyHidden` taken from @guardian/source-foundations
         css={css`

--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -65,7 +65,7 @@ const JournalismPage = () => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main">
       <FullWidthText theme="dark" title="Journalism">
         <p>
           The Guardian has a global reputation for holding power to account and

--- a/src/pages/organisation/index.tsx
+++ b/src/pages/organisation/index.tsx
@@ -85,7 +85,7 @@ const HomePage = () => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main">
       <FullWidthText theme="dark" title="Our organisation">
         <>
           <p>


### PR DESCRIPTION
## What does this change?

Remove unnecessary `tabindex` from content with an `id`.

## How to test

Tab-tab-tab!

## How can we measure success?

Recommended by the DAC in https://github.com/guardian/dotcom-rendering/issues/5077

Aligned with DCR https://github.com/guardian/dotcom-rendering/pull/5991

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [X] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [X] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
