### PR TITLE
Remove redundant tab index

### DIFF
--- a/src/pages/history/index.tsx
+++ b/src/pages/history/index.tsx
@@ -62,7 +62,7 @@ const OurHistory = () => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main">
       <FullWidthText theme="dark" title="Our history">
         <>
           <p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -76,7 +76,7 @@ const HomePage = (): jsx.JSX.Element => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main">
       <h1
         // This is a copy of `visuallyHidden` taken from @guardian/source-foundations
         css={css`

--- a/src/pages/journalism/index.tsx
+++ b/src/pages/journalism/index.tsx
@@ -65,7 +65,7 @@ const JournalismPage = () => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main">
       <FullWidthText theme="dark" title="Journalism">
         <p>
           The Guardian has a global reputation for holding power to account and

--- a/src/pages/organisation/index.tsx
+++ b/src/pages/organisation/index.tsx
@@ -85,7 +85,7 @@ const HomePage = () => (
         },
       ]}
     />
-    <main id="main" tabIndex={-1}>
+    <main id="main">
       <FullWidthText theme="dark" title="Our organisation">
         <>
           <p>


### PR DESCRIPTION
## What does this change?

Remove redundant tab index from about us pages.

