### PR TITLE
Product prop design updates

### DIFF
--- a/src/components/detailsAndImage.tsx
+++ b/src/components/detailsAndImage.tsx
@@ -28,7 +28,6 @@ const containerCss = css`
 
 const readerFundingContainerCss = css`
   border-top: none;
-  padding-top: 0;
 
   ${from.tablet} {
     border-top: 1px solid ${neutral[86]};
@@ -52,15 +51,20 @@ const readerFundingProfileImgCss = css`
   margin: auto;
 
   ${from.tablet} {
-    margin-bottom: -43px;
+    margin-bottom: -38px;
+  }
+
+  ${from.desktop} {
+    margin-bottom: -44px;
   }
 
   ${from.wide} {
     width: calc(50% - 29px);
+    margin-bottom: -51px;
   }    
 `;
 
-const figcationCss = css`
+const figcaptionCss = css`
   display: block;
   width: 100%;
   margin: ${space[2]}px 0 0;
@@ -108,7 +112,8 @@ const bodyCopyCss = css`
 `;
 
 export const DetailsAndImage = (props: DetailsAndImageProps) => {
-  const isReaderFunding = props.title === 'Reader Funding';
+  const isReaderFunding = props.title === 'Reader funding';
+
   return (
     <figure css={[containerCss, isReaderFunding && readerFundingContainerCss]}>
       <img
@@ -116,7 +121,7 @@ export const DetailsAndImage = (props: DetailsAndImageProps) => {
         css={[profileImgCss, isReaderFunding && readerFundingProfileImgCss]}
         loading="lazy"
       />
-      <figcaption css={figcationCss}>
+      <figcaption css={figcaptionCss}>
         <h2 css={[titleCss, isReaderFunding && readerFundingTitleCss]}>{props.title}</h2>
         <p css={bodyCopyCss}>{props.bodyCopy}</p>
         <LinkButton

--- a/src/components/innerText.tsx
+++ b/src/components/innerText.tsx
@@ -46,7 +46,7 @@ const InnerText = (props: InnerTextProps) => {
     }
     ${minWidth.desktop} {
       font-size: 50px;
-      margin: 0 0 27px 0;
+      margin: 20px 0 27px 0;
     }
   `;
 

--- a/src/components/innerText.tsx
+++ b/src/components/innerText.tsx
@@ -39,7 +39,7 @@ const InnerText = (props: InnerTextProps) => {
     max-width: 608px;
     font-size: 32px;
     line-height: 1.15;
-    margin: 0 0 18px 0;
+    margin: 10px 0 18px 0;
     color: ${props.theme == "dark" ? neutral[100] : "inherit"};
     ${minWidth.tablet} {
       font-size: 42px;

--- a/src/components/reader-funded/readerFundedSubscribeCard.tsx
+++ b/src/components/reader-funded/readerFundedSubscribeCard.tsx
@@ -80,7 +80,7 @@ const ReaderFundedSubscribeCard = (props: ReaderFundedSubscribeCardProps) => {
 
   return (
     <div css={container}>
-      <img src={props.imagePath} css={image} />
+      <img src={props.imagePath} css={image} alt="" />
       <div css={copyContainer}>
         <div>
           <a css={link} href={props.href}>

--- a/src/components/reader-funded/readerFundedSubscribeCard.tsx
+++ b/src/components/reader-funded/readerFundedSubscribeCard.tsx
@@ -76,21 +76,11 @@ const ReaderFundedSubscribeCard = (props: ReaderFundedSubscribeCardProps) => {
     ${until.tablet} {
       display: none;
     }
-
-    ${from.tablet} {
-      width: 100%;
-      margin: 0 auto;
-      padding-top: 31%;
-      background-size: contain;
-      background-repeat: no-repeat;
-      background-position: right top;
-      background-image: url(${props.imagePath});
-    }
   `;
 
   return (
     <div css={container}>
-      <div css={image} />
+      <img src={props.imagePath} css={image} />
       <div css={copyContainer}>
         <div>
           <a css={link} href={props.href}>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -120,7 +120,6 @@ const HomePage = (): jsx.JSX.Element => (
         theme="light"
         background={{ backgroundColor: `${neutral[97]}` }}
         overlapTop={true}
-        paddingBottom={true}
       >
         <>
           <InnerText title="Our Organisation" theme="light">
@@ -205,7 +204,7 @@ const HomePage = (): jsx.JSX.Element => (
               title="Newspaper"
               bodyText="Convenient and money-saving, get a newspaper delivered to your door, or pick it up from your local shop. Choose your subscription, from daily to weekend-only."
               href="https://support.theguardian.com/subscribe/paper"
-              imagePath= "/about/images/newspaper-desktop.png" />
+              imagePath="/about/images/newspaper-desktop.png" />
             <ReaderFundedSubscribeCard
               title="Guardian Weekly"
               bodyText="Explore the stories that shaped the week with our magazine, delivered worldwide. From top news picks to insightful opinion pieces and engaging long reads."

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -180,7 +180,7 @@ const HomePage = (): jsx.JSX.Element => (
         background={{ backgroundColor: `${neutral[97]}` }}
       >
         <>
-          <InnerText title="We're reader funded" theme="dark">
+          <InnerText title="We’re reader funded" theme="dark">
             <p
               css={css`
                 max-width: 850px;

--- a/src/pages/organisation/index.tsx
+++ b/src/pages/organisation/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxRuntime classic /
 /** @jsx jsx */
-import { jsx } from "@emotion/react";
+import { css, jsx } from "@emotion/react";
 import React from "react";
 import BoxContainer, {
   boxContainerPadding,
@@ -31,6 +31,10 @@ import Head from "next/head";
 const Footer = dynamic(() => import("../../components/footer/footer"), {
   ssr: false,
 });
+
+const marginTop = css`
+  margin-top: 0;
+`
 
 const ourStructureBkg = {
   mobile: `linear-gradient(to top, #052962 41px, ${neutral[97]} 41px)`,
@@ -291,7 +295,7 @@ const HomePage = () => (
             bodyCopy="Guardian readers can show their financial support for our journalism by giving a single amount as often as they like, or by setting up a recurring payment every month or year. To support at a higher level, they can join our Patrons programme."
             readMoreUrl="https://www.theguardian.com/media/2022/dec/09/what-do-you-get-when-you-support-the-guardian-supporter-subscribe-contribute"
           />
-          <div css={threeColumnResponsiveCardHolder}>
+          <div css={[threeColumnResponsiveCardHolder, marginTop]}>
             <ResponsiveCardVariant1
               title="Advertising"
               imagePath="/about/images/organisation-18.jpg"

--- a/src/styles/sharedStyles.tsx
+++ b/src/styles/sharedStyles.tsx
@@ -216,12 +216,15 @@ export const readerFundedHeadingCss = css`
 `;
 
 export const printReaderFundedHeadingCss = css`
+  font-size: 20px;
+
   ${minWidth.tablet} {
+    font-size: 24px;
     margin-bottom: 2px;
   };
 `;
 
-export const supportReaderFundedHeadingCss =  css`
+export const supportReaderFundedHeadingCss = css`
   font-size: 32px;
   color: ${brandAlt[400]};
   padding-top: ${space[2]}px;


### PR DESCRIPTION
## What does this change?
Following https://github.com/guardian/about-us/pull/102 this adds further product prop related design changes to the about us pages.

## Images
**Before**
| mob | desktop | 
| -- | -- |
| <img width="185" alt="Screenshot 2023-01-04 at 09 59 47" src="https://user-images.githubusercontent.com/44685872/210531479-ba9c1704-c7e4-4230-a2b6-216fb64088e9.png"> | <img width="485" alt="Screenshot 2023-01-04 at 10 02 44" src="https://user-images.githubusercontent.com/44685872/210531491-6bb50620-aeff-49c6-aa9b-9aeb6464de65.png"> | 
| <img width="185" alt="Screenshot 2023-01-04 at 10 00 39" src="https://user-images.githubusercontent.com/44685872/210531485-1d1c142a-88b8-4e28-9ff4-7d0b537fbf01.png"> | <img width="488" alt="Screenshot 2023-01-04 at 10 03 21" src="https://user-images.githubusercontent.com/44685872/210531496-f7ae82e6-d8de-4c62-ac2c-70de7da71dc3.png"> |

**After**
| mob | desktop | 
| -- | -- |
| <img width="175" alt="Screenshot 2023-01-13 at 10 29 02" src="https://user-images.githubusercontent.com/44685872/212299210-466e74de-f10c-40b5-b8fc-12a5b40bfa8f.png"> | <img width="488" alt="Screenshot 2023-01-13 at 10 31 40" src="https://user-images.githubusercontent.com/44685872/212299216-39004914-a7d7-4082-a924-f8a975ab20d4.png"> |
| <img width="172" alt="Screenshot 2023-01-13 at 10 33 00" src="https://user-images.githubusercontent.com/44685872/212299228-366e680f-77dd-4475-80bb-c1976b2d5a9d.png"> | <img width="482" alt="Screenshot 2023-01-13 at 10 32 33" src="https://user-images.githubusercontent.com/44685872/212299221-f515e406-5f40-492f-a563-7ca89a86016e.png"> |
