### PR TITLE
Fix print sub images

### DIFF
--- a/src/components/reader-funded/readerFundedSubscribeCard.tsx
+++ b/src/components/reader-funded/readerFundedSubscribeCard.tsx
@@ -76,6 +76,15 @@ const ReaderFundedSubscribeCard = (props: ReaderFundedSubscribeCardProps) => {
     ${until.tablet} {
       display: none;
     }
+
+    ${from.tablet} {
+      object-fit: contain;
+      max-height: 120px
+    }
+
+    ${from.desktop} {
+      max-height: 130px
+    }
   `;
 
   return (


### PR DESCRIPTION
## What does this change?
This fixes a visual bug on older versions of Safari where images in the print subs section were being stretched undesirably (please see images below).

## How can we measure success?
These images do not appear stretched on major versions of Safari prior to version 16.

## Images
| Before | After |
| -- | -- |
| <img width="1139" alt="image" src="https://user-images.githubusercontent.com/44685872/212676059-ecbe3856-473f-40a0-b7a2-bd22db29b60c.png"> | <img width="863" alt="Screenshot 2023-01-16 at 12 02 43" src="https://user-images.githubusercontent.com/44685872/212675811-278763b0-fd31-4619-83ee-dd043e9ae7ab.png"> |


