### PR TITLE
Pin snyk workflow version

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   security:
-    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@2b60386db029f20e6f936b4b081881ea74af0077
     with:
       DEBUG: true
       ORG: guardian-dotcom-n2y


### PR DESCRIPTION
## What does this change?

Pins a specific commit for the snyk workflow. A recent change has broken this action for us, so this is to maintain coverage while we work out whether this is an issue upstream or with us.