### PR TITLE
Update snyk workflow to skip SBT

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,18 +1,18 @@
-# This action runs snyk monitor on every push to main
-name: Snyk
-
+name: DCR Snyk
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
-
+    schedule:
+        - cron: '0 6 * * *'
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+permissions:
+  contents: read
 jobs:
-  security:
-    uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
-    with:
-      DEBUG: true
-      ORG: guardian-dotcom-n2y
-      SKIP_NODE: false
-    secrets:
-       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+    security:
+        uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
+        with:
+            ORG: guardian-dotcom-n2y
+            SKIP_SBT: true
+        secrets:
+            SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}


### PR DESCRIPTION
## What does this change?

Adds `SKIP_SBT: true` so we avoid having [trying to run java Snyk](https://github.com/guardian/about-us/actions/runs/4294888444/jobs/7485354290).

Updates the `yml` file to match [dotcom-rendering's version](https://github.com/guardian/dotcom-rendering/blob/main/.github/workflows/dcr-snyk.yml).

