### PR TITLE
hide S3 bucket bucket name in `riff-raff.yaml`

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -6,7 +6,8 @@ deployments:
   gu-about-us-upload:
     type: aws-s3
     parameters:
-      bucket: gu-about-us
+      bucketSsmLookup: true
+      bucketSsmKey: /account/services/about-us.bucket
       prefixStack: false
       publicReadAcl: true
       cacheControl: public, max-age=300, stale-while-revalidate=60


### PR DESCRIPTION
## What does this change?

- use `bucketSsmLookup` and `bucketSsmKey`, so RiffRaff can lookup the target S3 bucket name instead of putting it in this repo
  - The Gu recommendations (https://github.com/guardian/recommendations/blob/0381138afe5b6be4843951458cad7a4fa142fca1/github.md?plain=1#L100) indicate that S3 bucket names should be hidden from public repos

Closes #111 