### PR TITLE
add `@guardian/dotcom-platform` as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @guardian/dotcom-platform


### PR DESCRIPTION
## What does this change?

Adds `@guardian/dotcom-platform` as codeowners of this repository