### PR TITLE
Update footer links

### DIFF
--- a/src/components/footer/footerlinks.tsx
+++ b/src/components/footer/footerlinks.tsx
@@ -62,7 +62,7 @@ export const footerLinks: FooterLink[][] = [
     },
     {
       title: "Modern Slavery Act",
-      link: `https://${domain}/info/2016/jul/27/modern-slavery-and-our-supply-chains?INTCMP=NGW_FOOTER_UK_GU_MODERN_SLAVERY_ACT`,
+      link: `https://uploads.guim.co.uk/2022/07/20/STL_Modern_Slavery_Statement_2022.pdf`,
     },
     {
       title: "Digital newspaper archive",

--- a/src/components/footer/footerlinks.tsx
+++ b/src/components/footer/footerlinks.tsx
@@ -107,10 +107,6 @@ export const footerLinks: FooterLink[][] = [
       link: `https://jobs.${domain}/?INTCMP=NGW_FOOTER_UK_GU_JOBS`,
     },
     {
-      title: "Dating",
-      link: `https://soulmates.${domain}/?INTCMP=NGW_FOOTER_UK_GU_SOULMATES`,
-    },
-    {
       title: "Patrons",
       link: `https://patrons.${domain}/?INTCMP=footer_patrons`,
     },


### PR DESCRIPTION
## What does this change?

- Removes link to Guardian Dating (Soulmates) as the service no longer exists
- Updates link to modern slavery act, to use the same location as Dotcom

