### PR TITLE
Bump CMP to allow for MSPS changes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.10.6",
-        "@guardian/consent-management-platform": "^13.7.1",
+        "@guardian/consent-management-platform": "^13.8.0",
         "@guardian/source-foundations": "^12.0.0",
         "@guardian/source-react-components": "^15.0.0",
         "next": "^13.3.0",
@@ -277,9 +277,9 @@
       }
     },
     "node_modules/@guardian/consent-management-platform": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.7.1.tgz",
-      "integrity": "sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.8.0.tgz",
+      "integrity": "sha512-J8YBXxpl/oGLmDGtjvkSwGmkaTJtnr/rxmYJAynaX0dkqopdDvG9REdbxMZBz3kugBpqHzhREzAk5Ut/uiyl8w==",
       "peerDependencies": {
         "@guardian/libs": "^15.0.0"
       }
@@ -4057,9 +4057,9 @@
       "peer": true
     },
     "@guardian/consent-management-platform": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.7.1.tgz",
-      "integrity": "sha512-BtUNkuCqd++A0Wkk9CA4kI95yVZJk1YMjPdppEnmq3cG/ros4ElXN4cNG7pWifeTR5cUtJflAiRRO4L5ewASpQ==",
+      "version": "13.8.0",
+      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.8.0.tgz",
+      "integrity": "sha512-J8YBXxpl/oGLmDGtjvkSwGmkaTJtnr/rxmYJAynaX0dkqopdDvG9REdbxMZBz3kugBpqHzhREzAk5Ut/uiyl8w==",
       "requires": {}
     },
     "@guardian/eslint-plugin-source-foundations": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/guardian/about-us#readme",
   "dependencies": {
     "@emotion/react": "^11.10.6",
-    "@guardian/consent-management-platform": "^13.7.1",
+    "@guardian/consent-management-platform": "^13.8.0",
     "@guardian/source-foundations": "^12.0.0",
     "@guardian/source-react-components": "^15.0.0",
     "next": "^13.3.0",


### PR DESCRIPTION
## What does this change?

We are adding a new stub file and associated changes to allow for a new multi-state privacy string owing to regulatory changes in the US around privacy.  Trello card: https://trello.com/c/6qAHXGHq. 

## How to test

On branch, open in fresh Guest or incognito browser window and view the cookie banner.  Make a selection and in the browser's dev tool console window, check the version with `window.guCmpHotFix.cmp.version` -  this should match the version defined in package.json.

Scroll to the Footer and select Privacy Settings, the cookie banner should re-appear. 

## How can we measure success?

We can see the cookie banner

## Have we considered potential risks?

Our monitoring should pick up if the version isn't working.

## Images

No change

## Accessibility

No change