### PR TITLE
Bump consent-management-platform to version 13.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@emotion/react": "^11.10.6",
-        "@guardian/consent-management-platform": "^13.8.0",
+        "@guardian/consent-management-platform": "^13.11.1",
         "@guardian/source-foundations": "^12.0.0",
         "@guardian/source-react-components": "^15.0.0",
         "next": "^13.3.0",
@@ -277,11 +277,11 @@
       }
     },
     "node_modules/@guardian/consent-management-platform": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.8.0.tgz",
-      "integrity": "sha512-J8YBXxpl/oGLmDGtjvkSwGmkaTJtnr/rxmYJAynaX0dkqopdDvG9REdbxMZBz3kugBpqHzhREzAk5Ut/uiyl8w==",
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.11.1.tgz",
+      "integrity": "sha512-cU9ssmMVV6EpX7H9QVAf0gdPrIdrGkvi/5ylGXF6xGvyvJ6CwUxM+vZhhm5tujoCiq6EuAVJX1tiZ3oHQMEdZg==",
       "peerDependencies": {
-        "@guardian/libs": "^15.0.0"
+        "@guardian/libs": "^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@guardian/eslint-plugin-source-foundations": {
@@ -4057,9 +4057,9 @@
       "peer": true
     },
     "@guardian/consent-management-platform": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.8.0.tgz",
-      "integrity": "sha512-J8YBXxpl/oGLmDGtjvkSwGmkaTJtnr/rxmYJAynaX0dkqopdDvG9REdbxMZBz3kugBpqHzhREzAk5Ut/uiyl8w==",
+      "version": "13.11.1",
+      "resolved": "https://registry.npmjs.org/@guardian/consent-management-platform/-/consent-management-platform-13.11.1.tgz",
+      "integrity": "sha512-cU9ssmMVV6EpX7H9QVAf0gdPrIdrGkvi/5ylGXF6xGvyvJ6CwUxM+vZhhm5tujoCiq6EuAVJX1tiZ3oHQMEdZg==",
       "requires": {}
     },
     "@guardian/eslint-plugin-source-foundations": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/guardian/about-us#readme",
   "dependencies": {
     "@emotion/react": "^11.10.6",
-    "@guardian/consent-management-platform": "^13.8.0",
+    "@guardian/consent-management-platform": "^13.11.1",
     "@guardian/source-foundations": "^12.0.0",
     "@guardian/source-react-components": "^15.0.0",
     "next": "^13.3.0",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a final optional parameter for onConsentChange and bumps versions via dependabot.

## How to test

Open about in an incognito or guest window to view the cookie banner.  Interact with the cookie banner and that the version of CMP in the package.json file matches in the console window `window.guCmpHotFix.cmp.version`.

## How can we measure success?

Consent banner behaves as normal.

## Have we considered potential risks?

Can rollback to previous version if necessary.  Well tested.

## Images

N/A

## Accessibility

No change to UI