### PR TITLE
Bump actions-riff-raff to v4

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      pull-requests: write # Required for riff-raff action
+
     steps:
       - uses: actions/checkout@v3
 
@@ -20,16 +22,13 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
 
-      - uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-
       - run: npm ci
       - run: npm run build
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           app: "about-us"
           buildNumberOffset: 35
           configPath: riff-raff.yaml          


### PR DESCRIPTION
## What is the value of this and can you measure success?

Upgrades to use the latest version of `guardian/actions-riff-raff`.

Part of https://github.com/guardian/dotcom-rendering/issues/10600

## What does this change?

- Adds write permissions for pull requests and adds `githubToken` to the job step as [required in the major version bump for v3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0)
- Removes step to configure AWS credentials and uses the AWS role ARN directly in the riff-raff action [as required in the major bump for v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4)

## Checklist

- [x] Tested locally, and on CODE if necessary
  - [CODE deployment](https://riffraff.gutools.co.uk/deployment/view/2a91de72-cb63-4775-bf14-53d863a48e81)

