### PR TITLE
Remove scheduled Snyk run

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,7 +1,5 @@
 name: Snyk
 on:
-    schedule:
-        - cron: '0 6 * * *'
     push:
         branches:
             - main


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Remove scheduled Snyk run

## How can we measure success?

We only need to run Snyk when we update the main branch. There also appears to be a GH bug whereby when the schedule is automatically disabled, the whole action also gets disabled.

