### PR TITLE
Update Anna's photo

### DIFF
--- a/src/components/leadershipProfile.tsx
+++ b/src/components/leadershipProfile.tsx
@@ -61,6 +61,7 @@ export const LeadershipProfile = (props: LeadershipProfileProps) => {
     }
     border-radius: 50%;
     margin-right: ${space[5]}px;
+    object-fit: cover;
   `;
   const titleCss = css`
     ${headline.xxxsmall()};


### PR DESCRIPTION
## What does this change?

On request. 

We also add `object-fit: cover` as the two leadership photos have different sizes, so this ensures both render correctly. 


Before:
<img width="1124" alt="image" src="https://github.com/user-attachments/assets/36c2fd28-7356-451c-9296-085b1d1790fe" />


After:
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/34f589d8-aafb-4a20-8fce-47aa68f6e835" />
